### PR TITLE
[Feature] #9 - 자체 회원가입 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### application-local.yml ###
+src/main/resources/application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -17,15 +17,10 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
-    querydsl {}
 }
 
 repositories {
     mavenCentral()
-}
-
-ext {
-    querydslVersion = '5.1.0'
 }
 
 dependencies {
@@ -41,8 +36,8 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // ✅ QueryDSL (5.1.0)
-    implementation "com.querydsl:querydsl-jpa:$querydslVersion:jakarta"
-    annotationProcessor "com.querydsl:querydsl-apt:$querydslVersion:jakarta"
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
@@ -52,7 +47,7 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
-    // validation
+    // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -64,51 +59,19 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.apache.commons:commons-pool2' // 커넥션 풀링
+    // OAuth
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    // Query Parameter Log
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
 
-// QueryDSL 설정부
-def querydslDir = file("src/main/generated")
-
-sourceSets {
-    main {
-        java {
-            srcDirs += querydslDir
-        }
-    }
-}
-
-// Q 클래스 중복 생성 방지 및 자동 생성
-tasks.named('compileJava') {
-    doFirst {
-        if (querydslDir.exists()) {
-            querydslDir.deleteDir() // Q 클래스 중복 생성 방지
-        }
-        querydslDir.mkdirs()
-    }
-}
-
-tasks.register("compileQuerydsl", JavaCompile) {
-    group = "build"
-    description = "Generates the QueryDSL Q-types"
-    source = sourceSets.main.java
-    destinationDirectory = querydslDir
-    classpath = sourceSets.main.compileClasspath
-    options.annotationProcessorPath = configurations.annotationProcessor
-    options.compilerArgs = [
-            '-proc:only',
-            '-processor', 'com.querydsl.apt.jpa.JPAAnnotationProcessor'
-    ]
-}
-
-// compileJava는 항상 compileQuerydsl 이후에 실행
-compileJava {
-    dependsOn compileQuerydsl
-}
-
-jar {
-	enabled = false
+clean {
+    delete file('src/main/generated')
 }

--- a/src/main/java/PerfumeOnMe/spring/apiPayload/ApiResponse.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/ApiResponse.java
@@ -1,10 +1,11 @@
 package PerfumeOnMe.spring.apiPayload;
 
-import PerfumeOnMe.spring.apiPayload.code.BaseCode;
-import PerfumeOnMe.spring.apiPayload.code.status.SuccessStatus;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import PerfumeOnMe.spring.apiPayload.code.BaseCode;
+import PerfumeOnMe.spring.apiPayload.code.status.SuccessStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,24 +14,26 @@ import lombok.Getter;
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
 public class ApiResponse<T> {
 
-    @JsonProperty("isSuccess")
-    private final Boolean isSuccess;
-    private final String code;
-    private final String message;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private T result;
+	@JsonProperty("isSuccess")
+	private final Boolean isSuccess;
+	private final String code;
+	private final String message;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private T result;
 
+	// 200 OK
+	public static <T> ApiResponse<T> onSuccess(T result) {
+		return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), result);
+	}
 
-    public static <T> ApiResponse<T> onSuccess(T result){
-        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
-    }
+	// 201 CREATED, ...
+	public static <T> ApiResponse<T> of(BaseCode code, T result) {
+		return new ApiResponse<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(),
+			result);
+	}
 
-    public static <T> ApiResponse<T> of(BaseCode code, T result){
-            return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
-    }
-
-    // 실패한 경우 응답 생성
-    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
-        return new ApiResponse<>(false, code, message, data);
-    }
+	// 400 CLIENT, 500 SERVER 등 실패한 경우 응답 생성
+	public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
+		return new ApiResponse<>(false, code, message, data);
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -1,40 +1,51 @@
 package PerfumeOnMe.spring.apiPayload.code.status;
 
+import org.springframework.http.HttpStatus;
+
 import PerfumeOnMe.spring.apiPayload.code.BaseErrorCode;
 import PerfumeOnMe.spring.apiPayload.code.ErrorReasonDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
 
-    // 예시,,,
-    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
+	//일반적인 에러
+	_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+	_BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+	_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+	_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    private final HttpStatus httpStatus;
-    private final String code;
-    private final String message;
+	// 사용자 에러
+	LOGIN_ID_DUPLICATE(HttpStatus.BAD_REQUEST, "MEMBER4001", "이미 사용된 아이디입니다."),
+	PASSWORD_CONFIRM_FAIL(HttpStatus.BAD_REQUEST, "MEMBER4002", "비밀번호 확인을 실패했습니다."),
 
-    @Override
-    public ErrorReasonDTO getReason() {
-        return ErrorReasonDTO.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .build();
-    }
+	// 예시,,,
+	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
 
-    @Override
-    public ErrorReasonDTO getReasonHttpStatus() {
-        return ErrorReasonDTO.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(false)
-                .httpStatus(httpStatus)
-                .build()
-                ;
-    }
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+	@Override
+	public ErrorReasonDTO getReason() {
+		return ErrorReasonDTO.builder()
+			.message(message)
+			.code(code)
+			.isSuccess(false)
+			.build();
+	}
+
+	@Override
+	public ErrorReasonDTO getReasonHttpStatus() {
+		return ErrorReasonDTO.builder()
+			.message(message)
+			.code(code)
+			.isSuccess(false)
+			.httpStatus(httpStatus)
+			.build()
+			;
+	}
 }
 

--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/SuccessStatus.java
@@ -1,40 +1,42 @@
 package PerfumeOnMe.spring.apiPayload.code.status;
 
+import org.springframework.http.HttpStatus;
+
 import PerfumeOnMe.spring.apiPayload.code.BaseCode;
 import PerfumeOnMe.spring.apiPayload.code.ReasonDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum SuccessStatus implements BaseCode {
 
-    // 일반적인 응답
-    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+	// 일반적인 응답
+	_OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+	_CREATED(HttpStatus.OK, "COMMON201", "리소스를 성공적으로 생성했습니다.");
 
-    private final HttpStatus httpStatus;
-    private final String code;
-    private final String message;
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
 
-    @Override
-    public ReasonDTO getReason() {
-        return ReasonDTO.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(true)
-                .build();
-    }
+	@Override
+	public ReasonDTO getReason() {
+		return ReasonDTO.builder()
+			.message(message)
+			.code(code)
+			.isSuccess(true)
+			.build();
+	}
 
-    @Override
-    public ReasonDTO getReasonHttpStatus() {
-        return ReasonDTO.builder()
-                .message(message)
-                .code(code)
-                .isSuccess(true)
-                .httpStatus(httpStatus)
-                .build()
-                ;
-    }
+	@Override
+	public ReasonDTO getReasonHttpStatus() {
+		return ReasonDTO.builder()
+			.message(message)
+			.code(code)
+			.isSuccess(true)
+			.httpStatus(httpStatus)
+			.build()
+			;
+	}
 }
 

--- a/src/main/java/PerfumeOnMe/spring/config/security/SecurityConfig.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -18,9 +19,9 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.anyRequest().permitAll()
 			)
-			.formLogin(config -> config.disable())
-			.httpBasic(config -> config.disable())
-			.csrf(config -> config.disable());
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.csrf(AbstractHttpConfigurer::disable);
 
 		return http.build();
 	}

--- a/src/main/java/PerfumeOnMe/spring/config/security/SecurityConfig.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/SecurityConfig.java
@@ -4,23 +4,31 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
-                )
-                .formLogin(config -> config.disable())
-                .httpBasic(config -> config.disable())
-                .csrf(config -> config.disable());
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.authorizeHttpRequests(auth -> auth
+				.anyRequest().permitAll()
+			)
+			.formLogin(config -> config.disable())
+			.httpBasic(config -> config.disable())
+			.csrf(config -> config.disable());
 
-        return http.build();
-    }
+		return http.build();
+	}
+
+	// 문자열 암호화를 위한 PasswordEncoder 빈 등록
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
 }
 

--- a/src/main/java/PerfumeOnMe/spring/converter/UserConverter.java
+++ b/src/main/java/PerfumeOnMe/spring/converter/UserConverter.java
@@ -1,4 +1,23 @@
 package PerfumeOnMe.spring.converter;
 
+import PerfumeOnMe.spring.domain.User;
+import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
+
 public class UserConverter {
+
+	// 사용자 회원가입을 위한 엔티티로 변환
+	public static User toSignupUser(String name, String loginId, String password) {
+		return User.builder()
+			.name(name)
+			.loginId(loginId)
+			.password(password)
+			.build();
+	}
+
+	// 사용자를 회원가입 결과 DTO 반환
+	public static UserResponseDTO.SignupResult toSignupResult(User user) {
+		return UserResponseDTO.SignupResult.builder()
+			.userId(user.getId())
+			.build();
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/domain/User.java
+++ b/src/main/java/PerfumeOnMe/spring/domain/User.java
@@ -1,6 +1,5 @@
 package PerfumeOnMe.spring.domain;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,7 +10,6 @@ import PerfumeOnMe.spring.domain.base.BaseEntity;
 import PerfumeOnMe.spring.domain.enums.Age;
 import PerfumeOnMe.spring.domain.enums.Social;
 import PerfumeOnMe.spring.domain.enums.UserGender;
-import PerfumeOnMe.spring.domain.enums.UserStatus;
 import PerfumeOnMe.spring.domain.mapping.Diary;
 import PerfumeOnMe.spring.domain.mapping.UserFragrance;
 import PerfumeOnMe.spring.domain.mapping.UserNote;
@@ -47,10 +45,10 @@ public class User extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, unique = true, length = 25)
+	@Column(nullable = false)
 	private String name;
 
-	@Column(unique = true, length = 25)
+	@Column(unique = true, length = 10)
 	private String nickname;
 
 	@Enumerated(EnumType.STRING)
@@ -61,10 +59,7 @@ public class User extends BaseEntity {
 	@Column(columnDefinition = "VARCHAR(10) DEFAULT 'NONE'")
 	private UserGender gender;
 
-	@Column(nullable = false, unique = true, length = 30)
-	private String email;
-
-	@Column(nullable = false, unique = true, length = 30)
+	@Column(nullable = false, unique = true)
 	private String loginId;
 
 	@Column(columnDefinition = "TEXT", nullable = false)
@@ -73,12 +68,6 @@ public class User extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(columnDefinition = "VARCHAR(10) DEFAULT 'LOCAL'")
 	private Social social;
-
-	@Enumerated(EnumType.STRING)
-	@Column(columnDefinition = "VARCHAR(10) DEFAULT 'ACTIVE'", nullable = false)
-	private UserStatus status;
-
-	private LocalDate inactiveDate;
 
 	@Column(columnDefinition = "TEXT")
 	private String imageURL;

--- a/src/main/java/PerfumeOnMe/spring/domain/enums/UserStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/domain/enums/UserStatus.java
@@ -1,5 +1,0 @@
-package PerfumeOnMe.spring.domain.enums;
-
-public enum UserStatus {
-    ACTIVE, INACTIVE, DELETED
-}

--- a/src/main/java/PerfumeOnMe/spring/repository/user/UserRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/user/UserRepository.java
@@ -1,8 +1,12 @@
 package PerfumeOnMe.spring.repository.user;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import PerfumeOnMe.spring.domain.User;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
+
+	Optional<User> findUserByLoginId(String loginId);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserService.java
@@ -1,5 +1,9 @@
 package PerfumeOnMe.spring.service.user;
 
+import PerfumeOnMe.spring.web.dto.user.UserRequestDTO;
+import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
+
 public interface UserService {
 
+	UserResponseDTO.SignupResult signup(UserRequestDTO.Signup request);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
@@ -1,13 +1,57 @@
 package PerfumeOnMe.spring.service.user;
 
+import java.util.Optional;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
+import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
+import PerfumeOnMe.spring.converter.UserConverter;
+import PerfumeOnMe.spring.domain.User;
+import PerfumeOnMe.spring.repository.user.UserRepository;
+import PerfumeOnMe.spring.web.dto.user.UserRequestDTO;
+import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class UserServiceImpl {
+public class UserServiceImpl implements UserService {
 
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	// 사용자 회원가입
+	@Override
+	public UserResponseDTO.SignupResult signup(UserRequestDTO.Signup request) {
+
+		// RequestDTO 값 추출하기
+		String name = request.getName();
+		String loginId = request.getLoginId();
+		String password = request.getPassword();
+		String passwordConfirm = request.getPasswordConfirm();
+
+		/*
+		비즈니스 로직 검증
+		1. loginId 중복 확인
+		2. password와 passwordConfirm 일치 여부 확인
+		 */
+		Optional<User> findUser = userRepository.findUserByLoginId(loginId);
+		if (findUser.isPresent()) {
+			throw new GeneralException(ErrorStatus.LOGIN_ID_DUPLICATE);
+		}
+		if (!password.equals(passwordConfirm)) {
+			throw new GeneralException(ErrorStatus.PASSWORD_CONFIRM_FAIL);
+		}
+
+		// 사용자 정보 엔티티 변환 및 DB 저장
+		User newUser = UserConverter
+			.toSignupUser(name, loginId, passwordEncoder.encode(password));
+		userRepository.save(newUser);
+
+		// 사용자 회원가입 결과를 ResponseDTO로 응답
+		return UserConverter.toSignupResult(newUser);
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
@@ -38,9 +38,6 @@ public class UserController {
 				content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponseDTO.SignupResult.class))),
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "이미 사용된 아이디입니다."),
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4002", description = "비밀번호 확인을 실패했습니다."),
-		},
-		parameters = {
-			,
 		}
 	)
 	public ResponseEntity<ApiResponse<UserResponseDTO.SignupResult>> signup(

--- a/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
@@ -1,9 +1,22 @@
 package PerfumeOnMe.spring.web.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import PerfumeOnMe.spring.apiPayload.ApiResponse;
+import PerfumeOnMe.spring.apiPayload.code.status.SuccessStatus;
+import PerfumeOnMe.spring.service.user.UserService;
+import PerfumeOnMe.spring.web.dto.user.UserRequestDTO;
+import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,4 +26,26 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/users")
 @Tag(name = "User", description = "사용자 CRUD API")
 public class UserController {
+
+	private final UserService userService;
+
+	@PostMapping("/signup")
+	@Operation(
+		summary = "자체 회원가입 API",
+		description = "사용자의 이름, 아이디, 비밀번호, 비밀번호 확인 값을 입력받아 회원가입하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON201", description = "리소스를 성공적으로 생성했습니다.",
+				content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponseDTO.SignupResult.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4001", description = "이미 사용된 아이디입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4002", description = "비밀번호 확인을 실패했습니다."),
+		},
+		parameters = {
+			,
+		}
+	)
+	public ResponseEntity<ApiResponse<UserResponseDTO.SignupResult>> signup(
+		@RequestBody @Valid UserRequestDTO.Signup request) {
+		UserResponseDTO.SignupResult result = userService.signup(request);
+		return new ResponseEntity<>(ApiResponse.of(SuccessStatus._CREATED, result), HttpStatus.CREATED);
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/user/UserRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/user/UserRequestDTO.java
@@ -1,4 +1,43 @@
 package PerfumeOnMe.spring.web.dto.user;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class UserRequestDTO {
+
+	@Getter
+	@NoArgsConstructor
+	public static class Signup {
+		@NotBlank
+		@Schema(description = "사용자가 입력한 이름", example = "홍길동")
+		@Pattern(
+			regexp = "^[가-힣]+$",
+			message = "한글만 입력할 수 있으며, 공백 없이 1자 이상 입력해주세요."
+		)
+		private String name;
+		@NotBlank
+		@Schema(description = "사용자가 입력한 아이디", example = "umc123")
+		@Pattern(
+			regexp = "^[a-z0-9]+$",
+			message = "영어 소문자와 숫자만 입력할 수 있으며, 공백 없이 1자 이상 입력해주세요."
+		)
+		private String loginId;
+		@NotBlank
+		@Schema(description = "사용자가 입력한 비밀번호", example = "asdf1234")
+		@Pattern(
+			regexp = "^[A-Za-z\\d@$!%*?&#]{8,20}$",
+			message = "비밀번호는 영어 대소문자, 숫자, 특수문자(@$!%*?&#)만 허용되며, 공백 없이 8자 이상 20자 이하로 입력해주세요."
+		)
+		private String password;
+		@NotBlank
+		@Schema(description = "사용자가 입력한 비밀번호 확인", example = "asdf1234")
+		@Pattern(
+			regexp = "^[A-Za-z\\d@$!%*?&#]{8,20}$",
+			message = "비밀번호는 영어 대소문자, 숫자, 특수문자(@$!%*?&#)만 허용되며, 공백 없이 8자 이상 20자 이하로 입력해주세요."
+		)
+		private String passwordConfirm;
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/user/UserResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/user/UserResponseDTO.java
@@ -12,6 +12,6 @@ public class UserResponseDTO {
 	@AllArgsConstructor
 	@NoArgsConstructor
 	public static class SignupResult {
-		Long userId;
+		private Long userId;
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/user/UserResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/user/UserResponseDTO.java
@@ -1,4 +1,17 @@
 package PerfumeOnMe.spring.web.dto.user;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class UserResponseDTO {
+
+	@Builder
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class SignupResult {
+		Long userId;
+	}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,4 @@
+spring:
+  config:
+    activate:
+      on-profile: dev

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,3 +2,21 @@ spring:
   config:
     activate:
       on-profile: dev
+  datasource:
+    url: # RDS
+    username: # Username
+    password: # Password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  sql:
+    init:
+      mode: never
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+        use_sql_comments: true
+        default_batch_fetch_size: 1000
+    show-sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    default: local
+    default: dev

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    default: local


### PR DESCRIPTION
## 💡 관련 이슈

#9 

## 📢 작업 내용

- `build.gradle`
  - QueryDSL 설정 충돌 해결
  - Redis, OAuth, Query Parameter Log 의존성 추가
- `ErrorStatus`와 `SuccessStatus`에 Enum 추가
- 요청 및 응답 DTO 구현
  - 요청 DTO 필드(name, loginId, password, passwordConfirm)에 제약 조건 적용
- 요구사항 정의서에 맞도록 `User` 엔티티 필드 수정
- `UserConverter`, `UserRepository`, `UserService`, `UserController` 코드 구현

## 🗨️ 리뷰 요구사항(선택)

- 인텔리제이 Edit Configurations에서 Active Profiles에 local 작성해야 함 (아래 사진 참고)
![image](https://github.com/user-attachments/assets/9c604803-0f23-4c3b-ae91-7a3f12eb21bf)
- `application.yml`을 local과 dev로 분리
  - `application.yml`
    - 기본값을 dev로 설정 -> local이 아닌 곳(ex. 배포된 서버)에서 동작
  - `application-local.yml`
    - 각자의 local MySQL 정보 등록
    - `.gitignore`에 등록함 -> **각자 알아서 추가해서 쓰기**
  - `application-dev.yml`
    - 배포할 때 RDS 정보를 인텔리제이나 AWS 환경 변수에 등록
    - ddl-auto: 최초 한 번만 create로 설정하고, 나중에 update로 변경해야 함
- PR Review 최소 1명으로 변경

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
