### PR TITLE
[Feature] #16 - 향수 검색 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -29,9 +29,6 @@ public enum ErrorStatus implements BaseErrorCode {
 	// 향수 상세 페이지 에러
 	FRAGRANCE_NOT_FOUND(HttpStatus.BAD_REQUEST, "FRAGRANCE4001", "해당 ID에 해당하는 향수를 찾을 수 없습니다."),
 
-	// 향수 검색 에러
-	KEYWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "FRAGRANCE4002", "검색어가 두 글자 이상이어야 합니다."),
-
 	// 예시,,,
 	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
 

--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -29,6 +29,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	// 향수 상세 페이지 에러
 	FRAGRANCE_NOT_FOUND(HttpStatus.BAD_REQUEST, "FRAGRANCE4001", "해당 ID에 해당하는 향수를 찾을 수 없습니다."),
 
+	// 향수 검색 에러
+	KEYWORD_TOO_SHORT(HttpStatus.BAD_REQUEST, "FRAGRANCE4002", "검색어가 두 글자 이상이어야 합니다."),
+
 	// 예시,,,
 	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
 

--- a/src/main/java/PerfumeOnMe/spring/converter/FragranceConverter.java
+++ b/src/main/java/PerfumeOnMe/spring/converter/FragranceConverter.java
@@ -1,5 +1,6 @@
 package PerfumeOnMe.spring.converter;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -18,6 +19,9 @@ import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
 
 public class FragranceConverter {
 
+	/**
+	 * 향수 상세 페이지 조회 API
+	 */
 	public static FragranceResponseDTO.FragranceDetailResult toDetailDto(Fragrance fragrance) {
 		return FragranceResponseDTO.FragranceDetailResult.builder()
 			.id(fragrance.getId())
@@ -104,4 +108,31 @@ public class FragranceConverter {
 			.ingredients(ingredients)
 			.build();
 	}
+
+	/**
+	 * 향수 검색 API
+	 */
+	public static FragranceResponseDTO.FragranceSearchResult toSearchResultDto(Fragrance fragrance) {
+		Integer minPrice = fragrance.getFragrancePriceList().stream()
+			.map(fp -> fp.getPrice().getPrice())
+			.min(Comparator.naturalOrder()) // 각 향수의 최저가
+			.orElse(null);
+
+		return FragranceResponseDTO.FragranceSearchResult.builder()
+			.id(fragrance.getId())
+			.brand(fragrance.getBrand().getShowBrand())
+			.name(fragrance.getName())
+			.minPrice(minPrice)
+			.imageUrl(fragrance.getImageURL())
+			.build();
+	}
+
+	// toSearchResultDto 로 얻은 향수들의 리스트
+	public static List<FragranceResponseDTO.FragranceSearchResult> toSearchResultDtoList(
+		List<Fragrance> fragranceList) {
+		return fragranceList.stream()
+			.map(FragranceConverter::toSearchResultDto)
+			.collect(Collectors.toList());
+	}
+
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryCustom.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryCustom.java
@@ -10,5 +10,5 @@ import PerfumeOnMe.spring.domain.Fragrance;
 public interface FragranceRepositoryCustom {
 	Optional<Fragrance> findByIdWithAllDetails(Long id);
 
-	Page<Fragrance> findByKeyword(String keyword, Pageable pageable);
+	Page<Fragrance> findBySearchKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryCustom.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryCustom.java
@@ -2,8 +2,13 @@ package PerfumeOnMe.spring.repository.fragrance;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import PerfumeOnMe.spring.domain.Fragrance;
 
 public interface FragranceRepositoryCustom {
 	Optional<Fragrance> findByIdWithAllDetails(Long id);
+
+	Page<Fragrance> findByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryImpl.java
@@ -40,7 +40,7 @@ public class FragranceRepositoryImpl implements FragranceRepositoryCustom {
 	}
 
 	@Override
-	public Page<Fragrance> findByKeyword(String keyword, Pageable pageable) {
+	public Page<Fragrance> findBySearchKeyword(String keyword, Pageable pageable) {
 		QFragrance fragrance = QFragrance.fragrance;
 
 		// 실제 결과 데이터 조회

--- a/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryImpl.java
@@ -1,9 +1,15 @@
 package PerfumeOnMe.spring.repository.fragrance;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import PerfumeOnMe.spring.domain.Fragrance;
@@ -32,4 +38,32 @@ public class FragranceRepositoryImpl implements FragranceRepositoryCustom {
 
 		return Optional.ofNullable(result);
 	}
+
+	@Override
+	public Page<Fragrance> findByKeyword(String keyword, Pageable pageable) {
+		QFragrance fragrance = QFragrance.fragrance;
+
+		// 실제 결과 데이터 조회
+		List<Fragrance> content = queryFactory
+			.selectFrom(fragrance)
+			.where(containsKeyword(fragrance.name, keyword))
+			.offset(pageable.getOffset()) // 몇 번째부터 가져올지 (page * size)
+			.limit(pageable.getPageSize()) // 몇 개 가져올지
+			.fetch();
+
+		// 카운트 쿼리 -> 총 조회된 향수가 몇 개인지
+		Long count = queryFactory
+			.select(fragrance.count())
+			.from(fragrance)
+			.where(containsKeyword(fragrance.name, keyword))
+			.fetchOne();
+
+		// Page 객체 생성
+		return PageableExecutionUtils.getPage(content, pageable, () -> count != null ? count : 0);
+	}
+
+	private BooleanExpression containsKeyword(StringPath field, String keyword) {
+		return keyword == null ? null : field.containsIgnoreCase(keyword);
+	}
+
 }

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
@@ -1,8 +1,14 @@
 package PerfumeOnMe.spring.service.fragrance;
 
+import java.util.Map;
+
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
 
 public interface FragranceService {
+	// 향수 상세 API
 	FragranceResponseDTO.FragranceDetailResult getFragranceDetail(Long fragranceId);
+
+	// 향수 검색 API
+	Map<String, Object> searchFragrances(String keyword, int page, int size);
 }
 

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
@@ -36,7 +36,7 @@ public class FragranceServiceImpl implements FragranceService {
 	@Override
 	public Map<String, Object> searchFragrances(String keyword, int page, int size) {
 		PageRequest pageable = PageRequest.of(page, size);
-		Page<Fragrance> fragrancePage = fragranceRepository.findByKeyword(keyword, pageable);
+		Page<Fragrance> fragrancePage = fragranceRepository.findBySearchKeyword(keyword, pageable);
 
 		List<FragranceResponseDTO.FragranceSearchResult> dtoList = FragranceConverter.toSearchResultDtoList(
 			fragrancePage.getContent());

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
@@ -1,5 +1,11 @@
 package PerfumeOnMe.spring.service.fragrance;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,11 +24,28 @@ public class FragranceServiceImpl implements FragranceService {
 
 	private final FragranceRepository fragranceRepository;
 
+	// 향수 상세 API
 	@Override
 	public FragranceResponseDTO.FragranceDetailResult getFragranceDetail(Long fragranceId) {
 		Fragrance fragrance = fragranceRepository.findByIdWithAllDetails(fragranceId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.FRAGRANCE_NOT_FOUND));
 		return FragranceConverter.toDetailDto(fragrance);
+	}
+
+	// 향수 검색 API
+	@Override
+	public Map<String, Object> searchFragrances(String keyword, int page, int size) {
+		PageRequest pageable = PageRequest.of(page, size);
+		Page<Fragrance> fragrancePage = fragranceRepository.findByKeyword(keyword, pageable);
+
+		List<FragranceResponseDTO.FragranceSearchResult> dtoList = FragranceConverter.toSearchResultDtoList(
+			fragrancePage.getContent());
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("fragranceList", dtoList);
+		result.put("hasNext", fragrancePage.hasNext());
+
+		return result;
 	}
 
 }

--- a/src/main/java/PerfumeOnMe/spring/validation/annotation/ValidKeyword.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/annotation/ValidKeyword.java
@@ -1,0 +1,23 @@
+package PerfumeOnMe.spring.validation.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import PerfumeOnMe.spring.validation.validator.ValidKeywordValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = ValidKeywordValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidKeyword {
+	String message() default "검색어를 2글자 이상 입력해주세요.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/PerfumeOnMe/spring/validation/annotation/ValidPage.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/annotation/ValidPage.java
@@ -1,0 +1,23 @@
+package PerfumeOnMe.spring.validation.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import PerfumeOnMe.spring.validation.validator.PageValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = PageValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPage {
+	String message() default "page 는 0 이상이어야 합니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/PerfumeOnMe/spring/validation/annotation/ValidSize.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/annotation/ValidSize.java
@@ -1,0 +1,23 @@
+package PerfumeOnMe.spring.validation.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import PerfumeOnMe.spring.validation.validator.SizeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = SizeValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidSize {
+	String message() default "size 는 1 이상이어야 합니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/PerfumeOnMe/spring/validation/validator/PageValidator.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/validator/PageValidator.java
@@ -1,0 +1,13 @@
+package PerfumeOnMe.spring.validation.validator;
+
+import PerfumeOnMe.spring.validation.annotation.ValidPage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PageValidator implements ConstraintValidator<ValidPage, Integer> {
+
+	@Override
+	public boolean isValid(Integer value, ConstraintValidatorContext context) {
+		return value != null && value >= 0;
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/validation/validator/SizeValidator.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/validator/SizeValidator.java
@@ -1,0 +1,13 @@
+package PerfumeOnMe.spring.validation.validator;
+
+import PerfumeOnMe.spring.validation.annotation.ValidSize;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class SizeValidator implements ConstraintValidator<ValidSize, Integer> {
+
+	@Override
+	public boolean isValid(Integer value, ConstraintValidatorContext context) {
+		return value != null && value >= 1;
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/validation/validator/ValidKeywordValidator.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/validator/ValidKeywordValidator.java
@@ -1,0 +1,14 @@
+package PerfumeOnMe.spring.validation.validator;
+
+import PerfumeOnMe.spring.validation.annotation.ValidKeyword;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValidKeywordValidator implements ConstraintValidator<ValidKeyword, String> {
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		// null 또는 공백이거나 2자 미만일 경우 false
+		return value != null && value.trim().length() >= 2;
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
@@ -4,20 +4,22 @@ import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import PerfumeOnMe.spring.apiPayload.ApiResponse;
-import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
-import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
 import PerfumeOnMe.spring.service.fragrance.FragranceService;
+import PerfumeOnMe.spring.web.dto.fragrance.FragranceRequestDTO;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -38,6 +40,9 @@ public class FragranceController {
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FRAGRANCE4001", description = "해당 ID에 해당하는 향수를 찾을 수 없습니다.")
 		}
 	)
+	@Parameters({
+		@Parameter(name = "fragranceId", description = "향수 ID"),
+	})
 	public ResponseEntity<ApiResponse<FragranceResponseDTO.FragranceDetailResult>> getFragranceDetail(
 		@PathVariable("fragranceId") Long fragranceId) {
 		FragranceResponseDTO.FragranceDetailResult result = fragranceService.getFragranceDetail(fragranceId);
@@ -54,18 +59,17 @@ public class FragranceController {
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FRAGRANCE4002", description = "검색어를 2글자 이상 입력해주세요.")
 		}
 	)
+	@Parameters({
+		@Parameter(name = "keyword", description = "검색어"),
+		@Parameter(name = "page", description = "페이지 번호"),
+		@Parameter(name = "size", description = "한 페이지에 불러올 향수 개수")
+	})
 	public ResponseEntity<ApiResponse<Map<String, Object>>> searchFragrances(
-		@RequestParam String keyword, // 검색어
-		@RequestParam int page, // 페이지 번호
-		@RequestParam(defaultValue = "12") int size // 한 페이지에 불러올 향수 수 (default = 12)
+		@Valid @ModelAttribute FragranceRequestDTO.FragranceSearchRequest request
 	) {
-		// 검색어가 공백이거나 2글자 미만이면 KEYWORD_TOO_SHORT 발생
-		if (keyword == null || keyword.trim().length() < 2) {
-			throw new GeneralException(ErrorStatus.KEYWORD_TOO_SHORT);
-		}
-
 		// result 안에 fragranceList 와 hasNext 를 키로 갖는 구조
-		Map<String, Object> result = fragranceService.searchFragrances(keyword, page, size);
+		Map<String, Object> result = fragranceService.searchFragrances(request.getKeyword(), request.getPage(),
+			request.getSize());
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
@@ -1,12 +1,17 @@
 package PerfumeOnMe.spring.web.controller;
 
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import PerfumeOnMe.spring.apiPayload.ApiResponse;
+import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
+import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
 import PerfumeOnMe.spring.service.fragrance.FragranceService;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,11 +23,12 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/fragrances")
-@Tag(name = "Fragrance", description = "향수 조회 API")
+@Tag(name = "Fragrance", description = "향수 CRUD API")
 public class FragranceController {
 
 	private final FragranceService fragranceService;
 
+	// 향수 상세 API
 	@GetMapping("/{fragranceId}")
 	@Operation(
 		summary = "향수 상세 조회",
@@ -35,6 +41,31 @@ public class FragranceController {
 	public ResponseEntity<ApiResponse<FragranceResponseDTO.FragranceDetailResult>> getFragranceDetail(
 		@PathVariable("fragranceId") Long fragranceId) {
 		FragranceResponseDTO.FragranceDetailResult result = fragranceService.getFragranceDetail(fragranceId);
+		return ResponseEntity.ok(ApiResponse.onSuccess(result));
+	}
+
+	// 향수 검색 API
+	@GetMapping("/search")
+	@Operation(
+		summary = "향수 키워드 검색 (무한 스크롤)",
+		description = "keyword 로 향수 이름을 검색하고, 페이징 처리된 결과를 반환합니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "요청에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = FragranceResponseDTO.FragranceSearchResult.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FRAGRANCE4002", description = "검색어를 2글자 이상 입력해주세요.")
+		}
+	)
+	public ResponseEntity<ApiResponse<Map<String, Object>>> searchFragrances(
+		@RequestParam String keyword, // 검색어
+		@RequestParam int page, // 페이지 번호
+		@RequestParam(defaultValue = "12") int size // 한 페이지에 불러올 향수 수 (default = 12)
+	) {
+		// 검색어가 공백이거나 2글자 미만이면 KEYWORD_TOO_SHORT 발생
+		if (keyword == null || keyword.trim().length() < 2) {
+			throw new GeneralException(ErrorStatus.KEYWORD_TOO_SHORT);
+		}
+
+		// result 안에 fragranceList 와 hasNext 를 키로 갖는 구조
+		Map<String, Object> result = fragranceService.searchFragrances(keyword, page, size);
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceRequestDTO.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 public class FragranceRequestDTO {
+
+	// 향수 검색 응답 DTO
 	@Getter
 	@Setter
 	public static class FragranceSearchRequest {
@@ -18,6 +20,6 @@ public class FragranceRequestDTO {
 		private int page;
 
 		@ValidSize
-		private Integer size;
+		private int size;
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceRequestDTO.java
@@ -1,6 +1,8 @@
 package PerfumeOnMe.spring.web.dto.fragrance;
 
 import PerfumeOnMe.spring.validation.annotation.ValidKeyword;
+import PerfumeOnMe.spring.validation.annotation.ValidPage;
+import PerfumeOnMe.spring.validation.annotation.ValidSize;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,8 +14,10 @@ public class FragranceRequestDTO {
 		@ValidKeyword
 		private String keyword;
 
+		@ValidPage
 		private int page;
 
-		private Integer size = 12; // default
+		@ValidSize
+		private Integer size;
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceRequestDTO.java
@@ -1,0 +1,19 @@
+package PerfumeOnMe.spring.web.dto.fragrance;
+
+import PerfumeOnMe.spring.validation.annotation.ValidKeyword;
+import lombok.Getter;
+import lombok.Setter;
+
+public class FragranceRequestDTO {
+	@Getter
+	@Setter
+	public static class FragranceSearchRequest {
+
+		@ValidKeyword
+		private String keyword;
+
+		private int page;
+
+		private Integer size = 12; // default
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 public class FragranceResponseDTO {
 
-	// 향수 상세 페이지 응답 결과
+	// 향수 상세 DTO
 	@Getter
 	@Builder
 	@AllArgsConstructor
@@ -67,6 +67,19 @@ public class FragranceResponseDTO {
 			private String diffusionPower;
 		}
 	}
+
+	// 향수 검색 DTO
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class FragranceSearchResult {
+		private Long id;
+		private String brand;
+		private String name;
+		private Integer minPrice;
+		private String imageUrl;
+	}
+
 }
 
 

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
@@ -72,6 +72,7 @@ public class FragranceResponseDTO {
 	@Getter
 	@Builder
 	@AllArgsConstructor
+	@NoArgsConstructor
 	public static class FragranceSearchResult {
 		private Long id;
 		private String brand;

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 public class FragranceResponseDTO {
 
-	// 향수 상세 DTO
+	// 향수 상세 응답 DTO
 	@Getter
 	@Builder
 	@AllArgsConstructor
@@ -68,7 +68,7 @@ public class FragranceResponseDTO {
 		}
 	}
 
-	// 향수 검색 DTO
+	// 향수 검색 응답 DTO
 	@Getter
 	@Builder
 	@AllArgsConstructor

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,5 +18,5 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
         use_sql_comments: true
-        default_batch_fetch_size: 1000
+        default_batch_fetch_size: 100
     show-sql: true


### PR DESCRIPTION
## 💡 관련 이슈

#16 

## 📢 작업 내용

- **페이징 기반 무한 스크롤 응답 (page, size, hasNext 포함)**
- **응답 DTO에 향수 이름, 브랜드, 이미지 URL, 최소 가격 포함**
- **가장 작은 ml 기준 가격 추출 로직 적용 (FragrancePrice 기준)**
   - `Comparator.naturalOrder()` 을 사용하여 해당 향수의 price 중 가장 작은 값 반환
- **QueryDSL로 contains 검색 필터링 구현**
- **커스텀 어노테이션 및 Validator 추가**
   - `@ValidKeyword` :  향수 검색어가 2자 이상인지 검증하는 어노테이션
   - `@ValidPage` : 페이지 번호가 0 이상인지 검증
   - `@ValidSize` : 페이지당 사이즈가 1 이상인지 검증
- **DTO 구조 개선**
   - @ModelAttribute를 활용한 FragranceSearchRequest 내부 클래스 생성
   - 위 어노테이션들을 필드에 직접 적용하여 검증 수행

## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
