### PR TITLE
[Feature] #18 - 로그아웃 및 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -28,7 +28,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 토큰입니다."),
 	REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "TOKEN4002", "해당 리프레시 토큰이 존재하지 않습니다."),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4003", "만료된 토큰입니다."),
-	LOGOUT_ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "TOKEN4004", "로그아웃한 액세스 토큰이 존재하지 않습니다."),
+	LOGOUT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4004", "로그아웃한 액세스 토큰입니다."),
 	MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4005", "토큰 구조가 잘못됐습니다."),
 	UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4006", "지원하지 않는 토큰 형식입니다."),
 	INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "TOKEN4007", "토큰의 서명이 잘못됐습니다."),

--- a/src/main/java/PerfumeOnMe/spring/config/security/SecurityConfig.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
 	// 인증 여부를 확인하지 않을 경로 지정
 	public static final String[] AUTH_WHITELIST = {
 		"/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui.html", "/swagger-ui/**",
-		"/swagger/**", "/users/signup", "/auth/login", "/auth/social/kakao", "/users/reissue"
+		"/swagger/**", "/users/signup", "/auth/login", "/auth/social/kakao", "/users/reissue",
+		"/health"
 	};
 	private final JwtAuthenticationFilter JwtAuthenticationFilter;
 	private final JwtExceptionHandlerFilter JwtExceptionHandlerFilter;
@@ -43,7 +44,7 @@ public class SecurityConfig {
 			// 요청 경로별 인증 확인 설정
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(AUTH_WHITELIST).permitAll()
-				.anyRequest().authenticated()
+				.anyRequest().permitAll() // 개발 진행할 때 임시로 풀어두기 -> 나중에 authenticated()로 변경
 			)
 			// filter 레벨에서 발생하는 예외 핸들러 설정
 			.exceptionHandling(exception -> exception

--- a/src/main/java/PerfumeOnMe/spring/config/security/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/auth/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
+import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
+import PerfumeOnMe.spring.config.security.auth.manager.LogoutAccessTokenManager;
 import PerfumeOnMe.spring.config.security.auth.provider.JwtTokenProvider;
 import PerfumeOnMe.spring.config.security.auth.token.JwtAuthenticationToken;
 import jakarta.servlet.FilterChain;
@@ -27,6 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final AuthenticationManager authenticationManager;
+	private final LogoutAccessTokenManager logoutAccessTokenManager;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -36,6 +40,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		if (StringUtils.hasText(accessToken)) {
 			String loginId = jwtTokenProvider.getSubject(accessToken);
+
+			// 로그아웃된 액세스 토큰이 아닌 경우에만 JWT 인증 시도 및 설정
+			if (logoutAccessTokenManager.findLogoutAccessToken(loginId)) {
+				throw new GeneralException(ErrorStatus.LOGOUT_ACCESS_TOKEN);
+			}
+
 			JwtAuthenticationToken authRequest = new JwtAuthenticationToken(loginId, accessToken);
 			Authentication authResult = authenticationManager.authenticate(authRequest);
 			SecurityContextHolder.getContext().setAuthentication(authResult);

--- a/src/main/java/PerfumeOnMe/spring/config/security/auth/filter/JwtLoginFilter.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/auth/filter/JwtLoginFilter.java
@@ -22,6 +22,7 @@ import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
 import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
 import PerfumeOnMe.spring.config.security.auth.dto.AuthRequestDTO;
 import PerfumeOnMe.spring.config.security.auth.dto.AuthResponseDTO;
+import PerfumeOnMe.spring.config.security.auth.manager.LogoutAccessTokenManager;
 import PerfumeOnMe.spring.config.security.auth.manager.RefreshTokenManager;
 import PerfumeOnMe.spring.config.security.auth.provider.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
@@ -41,6 +42,7 @@ public class JwtLoginFilter extends UsernamePasswordAuthenticationFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RefreshTokenManager refreshTokenManager;
+	private final LogoutAccessTokenManager logoutAccessTokenManager;
 
 	private final ObjectMapper mapper = new ObjectMapper();
 
@@ -70,8 +72,15 @@ public class JwtLoginFilter extends UsernamePasswordAuthenticationFilter {
 	protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
 		FilterChain chain, Authentication authResult) throws IOException, ServletException {
 
-		// 토큰 생성 및 DTO에 담기
+		// Authentication에서 principal String 추출
 		String loginId = authResult.getName();
+
+		// 사용자의 로그아웃 액세스 토큰이 존재하는 경우 삭제
+		if (logoutAccessTokenManager.findLogoutAccessToken(loginId)) {
+			logoutAccessTokenManager.deleteLogoutAccessToken(loginId);
+		}
+
+		// 토큰 생성 및 DTO에 담기
 		String accessToken = jwtTokenProvider.createAccessToken(authResult);
 		String refreshToken = jwtTokenProvider.createRefreshToken(authResult);
 		AuthResponseDTO.RefreshToken refreshTokenDTO = AuthResponseDTO

--- a/src/main/java/PerfumeOnMe/spring/config/security/auth/manager/LogoutAccessTokenManager.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/auth/manager/LogoutAccessTokenManager.java
@@ -1,0 +1,42 @@
+package PerfumeOnMe.spring.config.security.auth.manager;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import PerfumeOnMe.spring.config.security.auth.provider.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LogoutAccessTokenManager {
+
+	private static final String LOGOUT_ACCESS_TOKEN_PREFIX = "Logout:";
+	private final StringRedisTemplate stringRedisTemplate;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public void saveLogoutAccessToken(String loginId, String accessToken) {
+		long expirationMillis = jwtTokenProvider.getExpiration(accessToken);
+		long nowMillis = System.currentTimeMillis();
+		long durationMillis = expirationMillis - nowMillis;
+
+		String key = LOGOUT_ACCESS_TOKEN_PREFIX + loginId;
+		stringRedisTemplate.opsForValue().set(key, accessToken, Duration.ofMillis(durationMillis));
+	}
+
+	public boolean findLogoutAccessToken(String loginId) {
+		String key = LOGOUT_ACCESS_TOKEN_PREFIX + loginId;
+		return stringRedisTemplate.hasKey(key);
+	}
+
+	public String getLogoutAccessToken(String loginId) {
+		String key = LOGOUT_ACCESS_TOKEN_PREFIX + loginId;
+		return stringRedisTemplate.opsForValue().get(key);
+	}
+
+	public void deleteLogoutAccessToken(String loginId) {
+		String key = LOGOUT_ACCESS_TOKEN_PREFIX + loginId;
+		stringRedisTemplate.delete(key);
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserService.java
@@ -3,6 +3,7 @@ package PerfumeOnMe.spring.service.user;
 import PerfumeOnMe.spring.config.security.auth.dto.AuthResponseDTO;
 import PerfumeOnMe.spring.web.dto.user.UserRequestDTO;
 import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface UserService {
@@ -10,4 +11,6 @@ public interface UserService {
 	UserResponseDTO.SignupResult signup(UserRequestDTO.Signup request);
 
 	AuthResponseDTO.RefreshToken reissue(String refreshToken, HttpServletResponse response);
+
+	void logout(HttpServletRequest request);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserService.java
@@ -12,5 +12,7 @@ public interface UserService {
 
 	AuthResponseDTO.RefreshToken reissue(String refreshToken, HttpServletResponse response);
 
-	void logout(HttpServletRequest request);
+	String logout(HttpServletRequest request);
+
+	void deleteUser(HttpServletRequest request);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
 import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
 import PerfumeOnMe.spring.config.security.auth.dto.AuthResponseDTO;
+import PerfumeOnMe.spring.config.security.auth.manager.LogoutAccessTokenManager;
 import PerfumeOnMe.spring.config.security.auth.manager.RefreshTokenManager;
 import PerfumeOnMe.spring.config.security.auth.provider.JwtTokenProvider;
 import PerfumeOnMe.spring.config.security.auth.token.JwtAuthenticationToken;
@@ -19,6 +20,7 @@ import PerfumeOnMe.spring.domain.User;
 import PerfumeOnMe.spring.repository.user.UserRepository;
 import PerfumeOnMe.spring.web.dto.user.UserRequestDTO;
 import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -31,6 +33,7 @@ public class UserServiceImpl implements UserService {
 	private final PasswordEncoder passwordEncoder;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RefreshTokenManager refreshTokenManager;
+	private final LogoutAccessTokenManager logoutAccessTokenManager;
 	private final UserDetailsService userDetailsService;
 
 	// 사용자 회원가입
@@ -86,5 +89,26 @@ public class UserServiceImpl implements UserService {
 		response.setHeader("Authorization", "Bearer " + accessToken);
 
 		return refreshTokenDTO;
+	}
+
+	// 사용자 로그아웃 - 액세스 토큰과 리프레시 토큰 블랙리스트화
+	@Override
+	public void logout(HttpServletRequest request) {
+
+		// 요청에서 액세스 토큰 추출 및 유효성 검증
+		String accessToken = jwtTokenProvider.resolveToken(request);
+		jwtTokenProvider.validateToken(accessToken);
+
+		// 토큰에서 loginId 추출 및 사용자 검증
+		String loginId = jwtTokenProvider.getSubject(accessToken);
+		userDetailsService.loadUserByUsername(loginId);
+
+		// 액세스 토큰 블랙리스트화
+		logoutAccessTokenManager.saveLogoutAccessToken(loginId, accessToken);
+
+		// 리프레시 토큰 삭제
+		if (refreshTokenManager.findRefreshToken(loginId)) {
+			refreshTokenManager.deleteRefreshToken(loginId);
+		}
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
@@ -93,7 +93,7 @@ public class UserServiceImpl implements UserService {
 
 	// 사용자 로그아웃 - 액세스 토큰과 리프레시 토큰 블랙리스트화
 	@Override
-	public void logout(HttpServletRequest request) {
+	public String logout(HttpServletRequest request) {
 
 		// 요청에서 액세스 토큰 추출 및 유효성 검증
 		String accessToken = jwtTokenProvider.resolveToken(request);
@@ -110,5 +110,15 @@ public class UserServiceImpl implements UserService {
 		if (refreshTokenManager.findRefreshToken(loginId)) {
 			refreshTokenManager.deleteRefreshToken(loginId);
 		}
+
+		return loginId;
+	}
+
+	// 회원탈퇴 - 로그아웃 진행 후 사용자 삭제
+	@Override
+	public void deleteUser(HttpServletRequest request) {
+		String loginId = logout(request);
+		Optional<User> findUser = userRepository.findUserByLoginId(loginId);
+		findUser.ifPresent(userRepository::delete);
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
@@ -15,7 +15,6 @@ import PerfumeOnMe.spring.service.user.UserService;
 import PerfumeOnMe.spring.web.dto.user.UserRequestDTO;
 import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -58,9 +57,6 @@ public class UserController {
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4003", description = "해당 아이디를 가진 사용자가 존재하지 않습니다."),
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TOKEN4002", description = "해당 리프레시 토큰이 존재하지 않습니다.")
-		},
-		parameters = {
-			@Parameter(name = "refreshToken", description = "Refresh-Token 헤더에 리프레시 토큰을 입력해 주세요.")
 		}
 	)
 	public ResponseEntity<ApiResponse<AuthResponseDTO.RefreshToken>> reissue(

--- a/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
@@ -2,6 +2,7 @@ package PerfumeOnMe.spring.web.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -76,6 +77,20 @@ public class UserController {
 	)
 	public ResponseEntity<ApiResponse<Object>> logout(HttpServletRequest request) {
 		userService.logout(request);
+		return ResponseEntity.ok().body(ApiResponse.onSuccess(null));
+	}
+
+	@DeleteMapping("/me")
+	@Operation(
+		summary = "회원탈퇴 API",
+		description = "사용자의 액세스 토큰과 리프레시 토큰을 블랙리스트화하고, 사용자를 삭제하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4003", description = "해당 아이디를 가진 사용자가 존재하지 않습니다."),
+		}
+	)
+	public ResponseEntity<ApiResponse<Object>> deleteUser(HttpServletRequest request) {
+		userService.deleteUser(request);
 		return ResponseEntity.ok().body(ApiResponse.onSuccess(null));
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -55,16 +56,30 @@ public class UserController {
 		description = "헤더에 입력한 Refresh-Token으로 새로운 액세스 토큰과 리프레시 토큰을 발급하는 API입니다.",
 		responses = {
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "", description = "")
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4003", description = "해당 아이디를 가진 사용자가 존재하지 않습니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "TOKEN4002", description = "해당 리프레시 토큰이 존재하지 않습니다.")
 		},
 		parameters = {
 			@Parameter(name = "refreshToken", description = "Refresh-Token 헤더에 리프레시 토큰을 입력해 주세요.")
 		}
 	)
 	public ResponseEntity<ApiResponse<AuthResponseDTO.RefreshToken>> reissue(
-		@RequestHeader(name = "Refresh-Token") String refreshToken,
-		HttpServletResponse response) {
+		@RequestHeader(name = "Refresh-Token") String refreshToken, HttpServletResponse response) {
 		AuthResponseDTO.RefreshToken result = userService.reissue(refreshToken, response);
 		return ResponseEntity.ok().body(ApiResponse.onSuccess(result));
+	}
+
+	@PostMapping("/logout")
+	@Operation(
+		summary = "로그아웃 API",
+		description = "사용자의 액세스 토큰과 리프레시 토큰을 블랙리스트화하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4003", description = "해당 아이디를 가진 사용자가 존재하지 않습니다."),
+		}
+	)
+	public ResponseEntity<ApiResponse<Object>> logout(HttpServletRequest request) {
+		userService.logout(request);
+		return ResponseEntity.ok().body(ApiResponse.onSuccess(null));
 	}
 }


### PR DESCRIPTION
## 💡 관련 이슈

#18 

## 📢 작업 내용

- **로그아웃 API 구현**
  - 기존 액세스 토큰 블랙리스트화
  - 블랙리스트에 있는 액세스 토큰으로 JWT 인증 요청하는 경우 예외 반환
  - 로그인할 때 블랙리스트에 있는 액세스 토큰 삭제
  - 새로운 리프레시 토큰으로 기존 리프레시 토큰 대체
- **회원탈퇴 API 구현**
  - 로그아웃 진행 후 사용자 삭제

## 🗨️ 리뷰 요구사항(선택)

- JWT 인증 안 하도록 해제해뒀습니다! 편하게 테스트하시면 됩니다.
- 기획상 필요 없는 API라서 그냥 바로 머지했습니다! 🙃

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
