### PR TITLE
[Feature] #24 - 향수 필터링 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -42,6 +42,14 @@ public enum ErrorStatus implements BaseErrorCode {
 	// 향수 상세 페이지 에러
 	FRAGRANCE_NOT_FOUND(HttpStatus.BAD_REQUEST, "FRAGRANCE4001", "해당 ID에 해당하는 향수를 찾을 수 없습니다."),
 
+	// 향수 필터링 에러
+	INVALID_GENDER(HttpStatus.BAD_REQUEST, "FILTER4001", "유효하지 않은 성별입니다."),
+	INVALID_FRAGRANCE_TYPE(HttpStatus.BAD_REQUEST, "FILTER4002", "유효하지 않은 향수 타입입니다."),
+	INVALID_NOTE_ID(HttpStatus.BAD_REQUEST, "FILTER4003", "유효하지 않은 노트 ID 입니다."),
+	INVALID_SEASON_ID(HttpStatus.BAD_REQUEST, "FILTER4004", "유효하지 않은 계절 ID 입니다."),
+	INVALID_SITUATION_ID(HttpStatus.BAD_REQUEST, "FILTER4005", "유효하지 않은 장소 ID 입니다."),
+	INVALID_PRICE_RANGE(HttpStatus.BAD_REQUEST, "FILTER4006", "가격 범위가 올바르지 않습니다."),
+
 	// 예시,,,
 	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
 

--- a/src/main/java/PerfumeOnMe/spring/converter/FragranceConverter.java
+++ b/src/main/java/PerfumeOnMe/spring/converter/FragranceConverter.java
@@ -112,6 +112,8 @@ public class FragranceConverter {
 	/**
 	 * 향수 검색 API
 	 */
+
+	// 향수 반환 dto 변환 처리
 	public static FragranceResponseDTO.FragranceSearchResult toSearchResultDto(Fragrance fragrance) {
 		Integer minPrice = fragrance.getFragrancePriceList().stream()
 			.map(fp -> fp.getPrice().getPrice())

--- a/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryCustom.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryCustom.java
@@ -6,9 +6,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import PerfumeOnMe.spring.domain.Fragrance;
+import PerfumeOnMe.spring.web.dto.fragrance.FragranceRequestDTO;
 
 public interface FragranceRepositoryCustom {
+	// 향수 상세
 	Optional<Fragrance> findByIdWithAllDetails(Long id);
 
+	// 향수 검색
 	Page<Fragrance> findBySearchKeyword(String keyword, Pageable pageable);
+
+	// 향수 필터링
+	Page<Fragrance> findByFilter(FragranceRequestDTO.FragranceFilterRequest request, Pageable pageable);
+
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryImpl.java
@@ -37,13 +37,24 @@ public class FragranceRepositoryImpl implements FragranceRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
 
+	// Q 도메인 객체를 클래스 레벨에서 선언
+	private final QFragrance f = QFragrance.fragrance;
+	private final QFragrancePrice fp = QFragrancePrice.fragrancePrice;
+	private final QPrice price = QPrice.price1;
+	private final QFragranceLocation fl = QFragranceLocation.fragranceLocation;
+	private final QLocation l = QLocation.location;
+	private final QFragranceSeason fs = QFragranceSeason.fragranceSeason;
+	private final QSeason s = QSeason.season;
+	private final QFragranceTopNote ftn = QFragranceTopNote.fragranceTopNote;
+	private final QFragranceMiddleNote fmn = QFragranceMiddleNote.fragranceMiddleNote;
+	private final QFragranceBaseNote fbn = QFragranceBaseNote.fragranceBaseNote;
+	private final QNote topNote = new QNote("topNote");
+	private final QNote middleNote = new QNote("middleNote");
+	private final QNote baseNote = new QNote("baseNote");
+
 	// 향수 상세
 	@Override
 	public Optional<Fragrance> findByIdWithAllDetails(Long id) {
-		QFragrance f = QFragrance.fragrance;
-		QFragrancePrice fp = QFragrancePrice.fragrancePrice;
-		QPrice price = QPrice.price1;
-
 		Fragrance result = queryFactory.selectFrom(f)
 			.leftJoin(f.fragrancePriceList, fp).fetchJoin()
 			.leftJoin(fp.price, price).fetchJoin()
@@ -56,21 +67,20 @@ public class FragranceRepositoryImpl implements FragranceRepositoryCustom {
 	//향수 검색
 	@Override
 	public Page<Fragrance> findBySearchKeyword(String keyword, Pageable pageable) {
-		QFragrance fragrance = QFragrance.fragrance;
 
 		// 실제 결과 데이터 조회
 		List<Fragrance> content = queryFactory
-			.selectFrom(fragrance)
-			.where(containsKeyword(fragrance.name, keyword))
+			.selectFrom(f)
+			.where(containsKeyword(f.name, keyword))
 			.offset(pageable.getOffset()) // 몇 번째부터 가져올지 (page * size)
 			.limit(pageable.getPageSize()) // 몇 개 가져올지
 			.fetch();
 
 		// 카운트 쿼리 -> 총 조회된 향수가 몇 개인지
 		Long count = queryFactory
-			.select(fragrance.count())
-			.from(fragrance)
-			.where(containsKeyword(fragrance.name, keyword))
+			.select(f.count())
+			.from(f)
+			.where(containsKeyword(f.name, keyword))
 			.fetchOne();
 
 		// Page 객체 생성
@@ -84,19 +94,6 @@ public class FragranceRepositoryImpl implements FragranceRepositoryCustom {
 	// 향수 필터링
 	@Override
 	public Page<Fragrance> findByFilter(FragranceRequestDTO.FragranceFilterRequest r, Pageable pageable) {
-		QFragrance f = QFragrance.fragrance;
-		QFragrancePrice fp = QFragrancePrice.fragrancePrice;
-		QPrice price = QPrice.price1;
-		QFragranceLocation fl = QFragranceLocation.fragranceLocation;
-		QLocation l = QLocation.location;
-		QFragranceSeason fs = QFragranceSeason.fragranceSeason;
-		QSeason s = QSeason.season;
-		QFragranceTopNote ftn = QFragranceTopNote.fragranceTopNote;
-		QFragranceMiddleNote fmn = QFragranceMiddleNote.fragranceMiddleNote;
-		QFragranceBaseNote fbn = QFragranceBaseNote.fragranceBaseNote;
-		QNote topNote = new QNote("topNote");
-		QNote middleNote = new QNote("middleNote");
-		QNote baseNote = new QNote("baseNote");
 
 		BooleanBuilder whereClause = new BooleanBuilder();
 

--- a/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepositoryImpl.java
@@ -4,18 +4,31 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import PerfumeOnMe.spring.domain.Fragrance;
 import PerfumeOnMe.spring.domain.QFragrance;
+import PerfumeOnMe.spring.domain.QLocation;
+import PerfumeOnMe.spring.domain.QNote;
 import PerfumeOnMe.spring.domain.QPrice;
+import PerfumeOnMe.spring.domain.QSeason;
+import PerfumeOnMe.spring.domain.enums.FragranceGender;
+import PerfumeOnMe.spring.domain.enums.FragranceType;
+import PerfumeOnMe.spring.domain.mapping.QFragranceBaseNote;
+import PerfumeOnMe.spring.domain.mapping.QFragranceLocation;
+import PerfumeOnMe.spring.domain.mapping.QFragranceMiddleNote;
 import PerfumeOnMe.spring.domain.mapping.QFragrancePrice;
+import PerfumeOnMe.spring.domain.mapping.QFragranceSeason;
+import PerfumeOnMe.spring.domain.mapping.QFragranceTopNote;
+import PerfumeOnMe.spring.web.dto.fragrance.FragranceRequestDTO;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -24,6 +37,7 @@ public class FragranceRepositoryImpl implements FragranceRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
 
+	// 향수 상세
 	@Override
 	public Optional<Fragrance> findByIdWithAllDetails(Long id) {
 		QFragrance f = QFragrance.fragrance;
@@ -39,6 +53,7 @@ public class FragranceRepositoryImpl implements FragranceRepositoryCustom {
 		return Optional.ofNullable(result);
 	}
 
+	//향수 검색
 	@Override
 	public Page<Fragrance> findBySearchKeyword(String keyword, Pageable pageable) {
 		QFragrance fragrance = QFragrance.fragrance;
@@ -66,4 +81,79 @@ public class FragranceRepositoryImpl implements FragranceRepositoryCustom {
 		return keyword == null ? null : field.containsIgnoreCase(keyword);
 	}
 
+	// 향수 필터링
+	@Override
+	public Page<Fragrance> findByFilter(FragranceRequestDTO.FragranceFilterRequest r, Pageable pageable) {
+		QFragrance f = QFragrance.fragrance;
+		QFragrancePrice fp = QFragrancePrice.fragrancePrice;
+		QPrice price = QPrice.price1;
+		QFragranceLocation fl = QFragranceLocation.fragranceLocation;
+		QLocation l = QLocation.location;
+		QFragranceSeason fs = QFragranceSeason.fragranceSeason;
+		QSeason s = QSeason.season;
+		QFragranceTopNote ftn = QFragranceTopNote.fragranceTopNote;
+		QFragranceMiddleNote fmn = QFragranceMiddleNote.fragranceMiddleNote;
+		QFragranceBaseNote fbn = QFragranceBaseNote.fragranceBaseNote;
+		QNote topNote = new QNote("topNote");
+		QNote middleNote = new QNote("middleNote");
+		QNote baseNote = new QNote("baseNote");
+
+		BooleanBuilder whereClause = new BooleanBuilder();
+
+		if (r.getFragranceType() != null) {
+			whereClause.and(f.fragranceType.eq(FragranceType.valueOf(r.getFragranceType())));
+		}
+		if (r.getGender() != null) {
+			whereClause.and(f.gender.eq(FragranceGender.valueOf(r.getGender())));
+		}
+		if (r.getSituationId() != null) {
+			whereClause.and(l.id.eq(r.getSituationId()));
+		}
+		if (r.getSeasonId() != null) {
+			whereClause.and(s.id.eq(r.getSeasonId()));
+		}
+		if (r.getNoteCategoryId() != null) {
+			BooleanBuilder noteBuilder = new BooleanBuilder();
+			noteBuilder.or(topNote.top.isTrue().and(topNote.id.eq(r.getNoteCategoryId())));
+			noteBuilder.or(middleNote.middle.isTrue().and(middleNote.id.eq(r.getNoteCategoryId())));
+			noteBuilder.or(baseNote.base.isTrue().and(baseNote.id.eq(r.getNoteCategoryId())));
+			whereClause.and(noteBuilder);
+		}
+		if (r.getPriceMin() != null && r.getPriceMax() != null) {
+			whereClause.and(price.price.between(r.getPriceMin(), r.getPriceMax()));
+		} else if (r.getPriceMin() != null) {
+			whereClause.and(price.price.goe(r.getPriceMin()));
+		} else if (r.getPriceMax() != null) {
+			whereClause.and(price.price.loe(r.getPriceMax()));
+		}
+
+		List<Fragrance> result = queryFactory.selectFrom(f)
+			.distinct()
+			.leftJoin(f.fragrancePriceList, fp).fetchJoin()
+			.leftJoin(fp.price, price)
+			.leftJoin(f.fragranceLocationList, fl).leftJoin(fl.location, l)
+			.leftJoin(f.fragranceSeasonList, fs).leftJoin(fs.season, s)
+			.leftJoin(f.fragranceTopNoteList, ftn).leftJoin(ftn.note, topNote)
+			.leftJoin(f.fragranceMiddleNoteList, fmn).leftJoin(fmn.note, middleNote)
+			.leftJoin(f.fragranceBaseNoteList, fbn).leftJoin(fbn.note, baseNote)
+			.where(whereClause)
+			.orderBy(f.name.asc()) // "가,나,다 순으로 정렬"
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = queryFactory.select(f.countDistinct())
+			.from(f)
+			.leftJoin(f.fragrancePriceList, fp)
+			.leftJoin(fp.price, price)
+			.leftJoin(f.fragranceLocationList, fl).leftJoin(fl.location, l)
+			.leftJoin(f.fragranceSeasonList, fs).leftJoin(fs.season, s)
+			.leftJoin(f.fragranceTopNoteList, ftn).leftJoin(ftn.note, topNote)
+			.leftJoin(f.fragranceMiddleNoteList, fmn).leftJoin(fmn.note, middleNote)
+			.leftJoin(f.fragranceBaseNoteList, fbn).leftJoin(fbn.note, baseNote)
+			.where(whereClause)
+			.fetchOne();
+
+		return new PageImpl<>(result, pageable, total != null ? total : 0);
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
@@ -2,6 +2,7 @@ package PerfumeOnMe.spring.service.fragrance;
 
 import java.util.Map;
 
+import PerfumeOnMe.spring.web.dto.fragrance.FragranceRequestDTO;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
 
 public interface FragranceService {
@@ -10,5 +11,9 @@ public interface FragranceService {
 
 	// 향수 검색 API
 	Map<String, Object> searchFragrances(String keyword, int page, int size);
+
+	// 향수 필터링 API
+	FragranceResponseDTO.FragranceSearchFinalResult searchFragrancesByFilter(
+		FragranceRequestDTO.FragranceFilterRequest request);
 }
 

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
@@ -3,9 +3,12 @@ package PerfumeOnMe.spring.service.fragrance;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,7 +16,13 @@ import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
 import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
 import PerfumeOnMe.spring.converter.FragranceConverter;
 import PerfumeOnMe.spring.domain.Fragrance;
+import PerfumeOnMe.spring.domain.enums.FragranceGender;
+import PerfumeOnMe.spring.domain.enums.FragranceType;
 import PerfumeOnMe.spring.repository.fragrance.FragranceRepository;
+import PerfumeOnMe.spring.repository.location.LocationRepository;
+import PerfumeOnMe.spring.repository.note.NoteRepository;
+import PerfumeOnMe.spring.repository.season.SeasonRepository;
+import PerfumeOnMe.spring.web.dto.fragrance.FragranceRequestDTO;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
 import lombok.RequiredArgsConstructor;
 
@@ -23,6 +32,9 @@ import lombok.RequiredArgsConstructor;
 public class FragranceServiceImpl implements FragranceService {
 
 	private final FragranceRepository fragranceRepository;
+	private final NoteRepository noteRepository;
+	private final SeasonRepository seasonRepository;
+	private final LocationRepository locationRepository;
 
 	// 향수 상세 API
 	@Override
@@ -42,10 +54,62 @@ public class FragranceServiceImpl implements FragranceService {
 			fragrancePage.getContent());
 
 		Map<String, Object> result = new HashMap<>();
-		result.put("fragranceList", dtoList);
+		result.put("content", dtoList);
 		result.put("hasNext", fragrancePage.hasNext());
 
 		return result;
+	}
+
+	// 향수 필터링 API
+	@Override
+	public FragranceResponseDTO.FragranceSearchFinalResult searchFragrancesByFilter(
+		FragranceRequestDTO.FragranceFilterRequest request) {
+
+		//  Enum 유효성 검사
+		if (request.getGender() != null) {
+			try {
+				FragranceGender.valueOf(request.getGender());
+			} catch (IllegalArgumentException e) {
+				throw new GeneralException(ErrorStatus.INVALID_GENDER);
+			}
+		}
+
+		if (request.getFragranceType() != null) {
+			try {
+				FragranceType.valueOf(request.getFragranceType());
+			} catch (IllegalArgumentException e) {
+				throw new GeneralException(ErrorStatus.INVALID_FRAGRANCE_TYPE);
+			}
+		}
+
+		// 가격 범위 유효성 검사
+		if (request.getPriceMin() != null && request.getPriceMax() != null
+			&& request.getPriceMin() > request.getPriceMax()) {
+			throw new GeneralException(ErrorStatus.INVALID_PRICE_RANGE);
+		}
+
+		// ID 존재 유효성 검사 (note, season, situation)
+		if (request.getNoteCategoryId() != null && !noteRepository.existsById(request.getNoteCategoryId())) {
+			throw new GeneralException(ErrorStatus.INVALID_NOTE_ID);
+		}
+		if (request.getSeasonId() != null && !seasonRepository.existsById(request.getSeasonId())) {
+			throw new GeneralException(ErrorStatus.INVALID_SEASON_ID);
+		}
+		if (request.getSituationId() != null && !locationRepository.existsById(request.getSituationId())) {
+			throw new GeneralException(ErrorStatus.INVALID_SITUATION_ID);
+		}
+
+		Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), Sort.by("name"));
+		Page<Fragrance> fragrancePage = fragranceRepository.findByFilter(request, pageable);
+
+		List<FragranceResponseDTO.FragranceSearchResult> content = fragrancePage.getContent().stream()
+			.map(FragranceConverter::toSearchResultDto)
+			.collect(Collectors.toList());
+
+		return FragranceResponseDTO.FragranceSearchFinalResult.builder()
+			.content(content)
+			.hasNext(fragrancePage.hasNext())
+			.build();
 	}
 
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
@@ -30,7 +30,9 @@ public class FragranceController {
 
 	private final FragranceService fragranceService;
 
-	// 향수 상세 API
+	/**
+	 * 향수 상세 API
+	 */
 	@GetMapping("/{fragranceId}")
 	@Operation(
 		summary = "향수 상세 조회",
@@ -49,7 +51,9 @@ public class FragranceController {
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
 
-	// 향수 검색 API
+	/**
+	 * 향수 검색 API
+	 */
 	@GetMapping("/search")
 	@Operation(
 		summary = "향수 키워드 검색 (무한 스크롤)",
@@ -72,4 +76,34 @@ public class FragranceController {
 			request.getSize());
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
+
+	/**
+	 * 향수 필터링 API
+	 */
+	@GetMapping("/filter")
+	@Operation(
+		summary = "향수 필터링 검색 (무한 스크롤)",
+		description = "필터링을 통해 걸러진 향수 목록을, 페이징 처리된 결과로 반환합니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "요청에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = FragranceResponseDTO.FragranceSearchResult.class))),
+		}
+	)
+	@Parameters({
+		@Parameter(name = "noteCategoryId", description = "향수 카테고리(노트) ID"),
+		@Parameter(name = "fragranceType", description = "향수 타입 필터"),
+		@Parameter(name = "gender", description = "성별 필터"),
+		@Parameter(name = "situationId", description = "사용하는 상황 필터(Location ID)"),
+		@Parameter(name = "seasonId", description = "계절 필터(계절 ID)"),
+		@Parameter(name = "priceMin", description = "최소 가격"),
+		@Parameter(name = "priceMax", description = "최대 가격"),
+		@Parameter(name = "page", description = "페이지 번호 (0부터 시작)"),
+		@Parameter(name = "size", description = "한 페이지에 불러올 향수 개수")
+	})
+	public ResponseEntity<ApiResponse<FragranceResponseDTO.FragranceSearchFinalResult>> searchFragrancesByFilter(
+		@Valid @ModelAttribute FragranceRequestDTO.FragranceFilterRequest request
+	) {
+		FragranceResponseDTO.FragranceSearchFinalResult result = fragranceService.searchFragrancesByFilter(request);
+		return ResponseEntity.ok(ApiResponse.onSuccess(result));
+	}
+
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
@@ -86,6 +86,12 @@ public class FragranceController {
 		description = "필터링을 통해 걸러진 향수 목록을, 페이징 처리된 결과로 반환합니다.",
 		responses = {
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "요청에 성공하였습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = FragranceResponseDTO.FragranceSearchResult.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FILTER4001", description = "유효하지 않은 성별입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FILTER4002", description = "유효하지 않은 향수 타입입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FILTER4003", description = "유효하지 않은 노트 ID 입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FILTER4004", description = "유효하지 않은 계절 ID 입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FILTER4005", description = "유효하지 않은 장소 ID 입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FILTER4006", description = "가격 범위가 올바르지 않습니다.")
 		}
 	)
 	@Parameters({

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceRequestDTO.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 
 public class FragranceRequestDTO {
 
-	// 향수 검색 응답 DTO
+	// 향수 검색 요청 DTO
 	@Getter
 	@Setter
 	public static class FragranceSearchRequest {
@@ -22,4 +22,32 @@ public class FragranceRequestDTO {
 		@ValidSize
 		private int size;
 	}
+
+	// 향수 필터링 요청 DTO
+	@Getter
+	@Setter
+	public static class FragranceFilterRequest {
+
+		private Long noteCategoryId;
+
+		private String gender;
+
+		private String fragranceType;
+
+		private Long situationId;
+
+		private Long seasonId;
+
+		private Integer priceMin;
+
+		private Integer priceMax;
+
+		@ValidPage
+		private Integer page;
+
+		@ValidSize
+		private Integer size;
+
+	}
+
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
@@ -68,7 +68,7 @@ public class FragranceResponseDTO {
 		}
 	}
 
-	// 향수 검색 응답 DTO
+	// 향수 검색,필터링 응답 DTO (각 향수 단건)
 	@Getter
 	@Builder
 	@AllArgsConstructor
@@ -81,6 +81,15 @@ public class FragranceResponseDTO {
 		private String imageUrl;
 	}
 
+	// 향수, 검색 필터링 응답 DTO (최종 응답)
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class FragranceSearchFinalResult {
+		private List<FragranceSearchResult> content;
+		private boolean hasNext;
+	}
 }
 
 


### PR DESCRIPTION
## 💡 관련 이슈

#24 

## 📢 작업 내용

- 필터링 대상 조건
    - **향수 카테고리**, **향수 타입**, **성별**, **사용하는 상황**, **계절**, **가격대**
- 필터링 로직
    - **그룹 간 AND**
        - 서로 다른 필터 그룹(카테고리, 타입, 성별 등) 간에는 모두 만족해야 조회
    - **미선택 그룹 제외**
        - 요청 파라미터에 없거나 빈 값이면 해당 그룹 필터는 적용하지 않음
    - 계열(노트 고르는 부분), 세부설정(향수타입, 성별, 상황,계절,가격)을 전부 포함하여 최소 하나라도 선택하여 나타낼 수 잇게끔. ( 아무것도 누르지 않는다면 전체 향수 리스트 나열과 다른게 없을 예정)
- 페이징 및 정렬
    - **정렬 기준**: 기본 ‘가나다’순
    - **페이징**:  무한스크롤
## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
