### PR TITLE
[Feature] #21 - 향수 즐겨찾기 등록 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -42,6 +42,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	// 향수 상세 페이지 에러
 	FRAGRANCE_NOT_FOUND(HttpStatus.BAD_REQUEST, "FRAGRANCE4001", "해당 ID에 해당하는 향수를 찾을 수 없습니다."),
 
+	// 향수 즐겨찾기 에러
+	ALREADY_FAVORITES_ERROR(HttpStatus.BAD_REQUEST, "FAVORITES4001", "이미 즐겨찾기에 등록한 향수입니다."),
+
 	// 예시,,,
 	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
 

--- a/src/main/java/PerfumeOnMe/spring/converter/FragranceConverter.java
+++ b/src/main/java/PerfumeOnMe/spring/converter/FragranceConverter.java
@@ -15,6 +15,7 @@ import PerfumeOnMe.spring.domain.mapping.FragranceMiddleNote;
 import PerfumeOnMe.spring.domain.mapping.FragrancePrice;
 import PerfumeOnMe.spring.domain.mapping.FragranceSeason;
 import PerfumeOnMe.spring.domain.mapping.FragranceTopNote;
+import PerfumeOnMe.spring.domain.mapping.UserFragrance;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
 
 public class FragranceConverter {
@@ -133,6 +134,13 @@ public class FragranceConverter {
 		return fragranceList.stream()
 			.map(FragranceConverter::toSearchResultDto)
 			.collect(Collectors.toList());
+	}
+
+	// 향수 즐겨찾기 등록 API
+	public static FragranceResponseDTO.FavoriteResponseDTO toFavoriteResponseDTO(UserFragrance userFragrance) {
+		return FragranceResponseDTO.FavoriteResponseDTO.builder()
+			.fragranceId(userFragrance.getFragrance().getId())
+			.build();
 	}
 
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/fragrance/FragranceRepository.java
@@ -8,4 +8,6 @@ import PerfumeOnMe.spring.domain.Fragrance;
 
 public interface FragranceRepository extends JpaRepository<Fragrance, Long>, FragranceRepositoryCustom {
 	Optional<Fragrance> findByName(String name);
+
+	Optional<Fragrance> findById(Long id);
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/user/UserRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/user/UserRepository.java
@@ -9,4 +9,6 @@ import PerfumeOnMe.spring.domain.User;
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
 	Optional<User> findUserByLoginId(String loginId);
+
+	Optional<User> findById(Long id);
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/userFragrance/UserFragranceRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/userFragrance/UserFragranceRepository.java
@@ -1,0 +1,11 @@
+package PerfumeOnMe.spring.repository.userFragrance;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import PerfumeOnMe.spring.domain.Fragrance;
+import PerfumeOnMe.spring.domain.User;
+import PerfumeOnMe.spring.domain.mapping.UserFragrance;
+
+public interface UserFragranceRepository extends JpaRepository<UserFragrance, Long> {
+	boolean existsByUserAndFragrance(User user, Fragrance fragrance);
+}

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
@@ -10,5 +10,8 @@ public interface FragranceService {
 
 	// 향수 검색 API
 	Map<String, Object> searchFragrances(String keyword, int page, int size);
+
+	// 향수 즐겨찾기 등록 API
+	FragranceResponseDTO.FavoriteResponseDTO addFavorite(Long userId, Long fragranceId);
 }
 

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
@@ -13,7 +13,11 @@ import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
 import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
 import PerfumeOnMe.spring.converter.FragranceConverter;
 import PerfumeOnMe.spring.domain.Fragrance;
+import PerfumeOnMe.spring.domain.User;
+import PerfumeOnMe.spring.domain.mapping.UserFragrance;
 import PerfumeOnMe.spring.repository.fragrance.FragranceRepository;
+import PerfumeOnMe.spring.repository.user.UserRepository;
+import PerfumeOnMe.spring.repository.userFragrance.UserFragranceRepository;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
 import lombok.RequiredArgsConstructor;
 
@@ -23,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 public class FragranceServiceImpl implements FragranceService {
 
 	private final FragranceRepository fragranceRepository;
+	private final UserRepository userRepository;
+	private final UserFragranceRepository userFragranceRepository;
 
 	// 향수 상세 API
 	@Override
@@ -46,6 +52,28 @@ public class FragranceServiceImpl implements FragranceService {
 		result.put("hasNext", fragrancePage.hasNext());
 
 		return result;
+	}
+
+	// 향수 즐겨찾기 등록 API
+	@Override
+	@Transactional(readOnly = false)
+	public FragranceResponseDTO.FavoriteResponseDTO addFavorite(Long userId, Long fragranceId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+		Fragrance fragrance = fragranceRepository.findById(fragranceId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.FRAGRANCE_NOT_FOUND));
+
+		if (userFragranceRepository.existsByUserAndFragrance(user, fragrance)) {
+			throw new GeneralException(ErrorStatus.ALREADY_FAVORITES_ERROR);
+		}
+
+		UserFragrance favorite = UserFragrance.builder()
+			.user(user)
+			.fragrance(fragrance)
+			.build();
+
+		userFragranceRepository.save(favorite);
+		return FragranceConverter.toFavoriteResponseDTO(favorite);
 	}
 
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
@@ -3,13 +3,16 @@ package PerfumeOnMe.spring.web.controller;
 import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import PerfumeOnMe.spring.apiPayload.ApiResponse;
+import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
 import PerfumeOnMe.spring.service.fragrance.FragranceService;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceRequestDTO;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
@@ -70,6 +73,28 @@ public class FragranceController {
 		// result 안에 fragranceList 와 hasNext 를 키로 갖는 구조
 		Map<String, Object> result = fragranceService.searchFragrances(request.getKeyword(), request.getPage(),
 			request.getSize());
+		return ResponseEntity.ok(ApiResponse.onSuccess(result));
+	}
+
+	// 향수 즐겨찾기 등록 API
+	@PostMapping("/{fragranceId}/favorites")
+	@Operation(
+		summary = "향수 즐겨찾기 등록",
+		description = "향수 ID로 향수 즐겨찾기를 등록하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "향수를 즐겨찾기에 등록했습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = FragranceResponseDTO.FavoriteResponseDTO.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FAVORITES4001", description = "이미 즐겨찾기에 등록한 향수입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FRAGRANCE4001", description = "해당 ID에 해당하는 향수를 찾을 수 없습니다.")
+		}
+	)
+	@Parameters({
+		@Parameter(name = "fragranceId", description = "향수 ID"),
+	})
+	public ResponseEntity<ApiResponse<FragranceResponseDTO.FavoriteResponseDTO>> addFavorite(
+		@PathVariable("fragranceId") Long fragranceId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		FragranceResponseDTO.FavoriteResponseDTO result = fragranceService.addFavorite(userDetails.getUserId(),
+			fragranceId);
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
@@ -81,6 +81,15 @@ public class FragranceResponseDTO {
 		private String imageUrl;
 	}
 
+	// 향수 즐겨찾기 등록 응답 DTO
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class FavoriteResponseDTO {
+		private Long fragranceId;
+	}
+
 }
 
 


### PR DESCRIPTION
## 💡 관련 이슈

#21

## 📢 작업 내용

- 기존 fragrance 관련 service, conver, controller 에서 작업
- repository만 따로 추가
- 현재 로그인한 userId를 jwt 토큰으로 부터 받아와 insert 진행

## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
