### PR TITLE
[Feature] #30 - 향수 즐겨찾기 취소 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -44,7 +44,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	// 향수 즐겨찾기 에러
 	ALREADY_FAVORITES_ERROR(HttpStatus.BAD_REQUEST, "FAVORITES4001", "이미 즐겨찾기에 등록한 향수입니다."),
-  
+	FAVORITE_NOT_FOUND(HttpStatus.BAD_REQUEST, "FAVORITES4002", "즐겨찾기 목록에 존재하지 않는 향수입니다."),
+
 	// 향수 필터링 에러
 	INVALID_GENDER(HttpStatus.BAD_REQUEST, "FILTER4001", "유효하지 않은 성별입니다."),
 	INVALID_FRAGRANCE_TYPE(HttpStatus.BAD_REQUEST, "FILTER4002", "유효하지 않은 향수 타입입니다."),

--- a/src/main/java/PerfumeOnMe/spring/converter/FragranceConverter.java
+++ b/src/main/java/PerfumeOnMe/spring/converter/FragranceConverter.java
@@ -145,4 +145,12 @@ public class FragranceConverter {
 			.build();
 	}
 
+	// 향수 즐겨찾기 취소 API
+	public static FragranceResponseDTO.FavoriteCancelResponseDTO toFavoriteCancelResponseDTO(
+		UserFragrance userFragrance) {
+		return FragranceResponseDTO.FavoriteCancelResponseDTO.builder()
+			.fragranceId(userFragrance.getFragrance().getId())
+			.build();
+	}
+
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/userFragrance/UserFragranceRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/userFragrance/UserFragranceRepository.java
@@ -1,5 +1,7 @@
 package PerfumeOnMe.spring.repository.userFragrance;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import PerfumeOnMe.spring.domain.Fragrance;
@@ -8,4 +10,6 @@ import PerfumeOnMe.spring.domain.mapping.UserFragrance;
 
 public interface UserFragranceRepository extends JpaRepository<UserFragrance, Long> {
 	boolean existsByUserAndFragrance(User user, Fragrance fragrance);
+
+	Optional<UserFragrance> findByUserAndFragrance(User user, Fragrance fragrance);
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/userFragrance/UserFragranceRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/userFragrance/UserFragranceRepository.java
@@ -8,7 +8,7 @@ import PerfumeOnMe.spring.domain.Fragrance;
 import PerfumeOnMe.spring.domain.User;
 import PerfumeOnMe.spring.domain.mapping.UserFragrance;
 
-public interface UserFragranceRepository extends JpaRepository<UserFragrance, Long> {
+public interface UserFragranceRepository extends JpaRepository<UserFragrance, Long>, UserFragranceRepositoryCustom {
 	boolean existsByUserAndFragrance(User user, Fragrance fragrance);
 
 	Optional<UserFragrance> findByUserAndFragrance(User user, Fragrance fragrance);

--- a/src/main/java/PerfumeOnMe/spring/repository/userFragrance/UserFragranceRepositoryCustom.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/userFragrance/UserFragranceRepositoryCustom.java
@@ -1,0 +1,5 @@
+package PerfumeOnMe.spring.repository.userFragrance;
+
+public interface UserFragranceRepositoryCustom {
+
+}

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
@@ -15,6 +15,9 @@ public interface FragranceService {
 	// 향수 즐겨찾기 등록 API
 	FragranceResponseDTO.FavoriteResponseDTO addFavorite(Long userId, Long fragranceId);
 
+	// 향수 즐겨찾기 취소 API
+	FragranceResponseDTO.FavoriteCancelResponseDTO deleteFavorite(Long userId, Long fragranceId);
+
 	// 향수 필터링 API
 	FragranceResponseDTO.FragranceSearchFinalResult searchFragrancesByFilter(
 		FragranceRequestDTO.FragranceFilterRequest request);

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
@@ -17,15 +17,15 @@ import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
 import PerfumeOnMe.spring.converter.FragranceConverter;
 import PerfumeOnMe.spring.domain.Fragrance;
 import PerfumeOnMe.spring.domain.User;
-import PerfumeOnMe.spring.domain.mapping.UserFragrance;
-import PerfumeOnMe.spring.repository.user.UserRepository;
-import PerfumeOnMe.spring.repository.userFragrance.UserFragranceRepository;
 import PerfumeOnMe.spring.domain.enums.FragranceGender;
 import PerfumeOnMe.spring.domain.enums.FragranceType;
+import PerfumeOnMe.spring.domain.mapping.UserFragrance;
 import PerfumeOnMe.spring.repository.fragrance.FragranceRepository;
 import PerfumeOnMe.spring.repository.location.LocationRepository;
 import PerfumeOnMe.spring.repository.note.NoteRepository;
 import PerfumeOnMe.spring.repository.season.SeasonRepository;
+import PerfumeOnMe.spring.repository.user.UserRepository;
+import PerfumeOnMe.spring.repository.userFragrance.UserFragranceRepository;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceRequestDTO;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -86,8 +86,24 @@ public class FragranceServiceImpl implements FragranceService {
 
 		userFragranceRepository.save(favorite);
 		return FragranceConverter.toFavoriteResponseDTO(favorite);
-  }
-  
+	}
+
+	// 향수 즐겨찾기 취소 API
+	@Override
+	@Transactional(readOnly = false)
+	public FragranceResponseDTO.FavoriteCancelResponseDTO deleteFavorite(Long userId, Long fragranceId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+		Fragrance fragrance = fragranceRepository.findById(fragranceId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.FRAGRANCE_NOT_FOUND));
+
+		UserFragrance favorite = userFragranceRepository.findByUserAndFragrance(user, fragrance)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.FAVORITE_NOT_FOUND));
+
+		userFragranceRepository.delete(favorite);
+		return FragranceConverter.toFavoriteCancelResponseDTO(favorite);
+	}
+
 	// 향수 필터링 API
 	@Override
 	public FragranceResponseDTO.FragranceSearchFinalResult searchFragrancesByFilter(

--- a/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -98,6 +99,28 @@ public class FragranceController {
 		@PathVariable("fragranceId") Long fragranceId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		FragranceResponseDTO.FavoriteResponseDTO result = fragranceService.addFavorite(userDetails.getUserId(),
+			fragranceId);
+		return ResponseEntity.ok(ApiResponse.onSuccess(result));
+	}
+
+	// 향수 즐겨찾기 취소 API
+	@DeleteMapping("/{fragranceId}/favorites")
+	@Operation(
+		summary = "향수 즐겨찾기 취소",
+		description = "향수 ID로 향수 즐겨찾기를 취소하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "즐겨찾기에서 향수를 제거했습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = FragranceResponseDTO.FavoriteCancelResponseDTO.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FAVORITES4002", description = "즐겨찾기 목록에 존재하지 않는 향수입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FRAGRANCE4001", description = "해당 ID에 해당하는 향수를 찾을 수 없습니다.")
+		}
+	)
+	@Parameters({
+		@Parameter(name = "fragranceId", description = "향수 ID"),
+	})
+	public ResponseEntity<ApiResponse<FragranceResponseDTO.FavoriteCancelResponseDTO>> deleteFavorite(
+		@PathVariable("fragranceId") Long fragranceId,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		FragranceResponseDTO.FavoriteCancelResponseDTO result = fragranceService.deleteFavorite(userDetails.getUserId(),
 			fragranceId);
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
@@ -82,14 +82,23 @@ public class FragranceResponseDTO {
 	}
 
 	// 향수 즐겨찾기 등록 응답 DTO
-  @Getter
+	@Getter
 	@Builder
 	@AllArgsConstructor
 	@NoArgsConstructor
-  public static class FavoriteResponseDTO {
+	public static class FavoriteResponseDTO {
 		private Long fragranceId;
 	}
-  
+
+	// 향수 즐겨찾기 등록 취소 DTO
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class FavoriteCancelResponseDTO {
+		private Long fragranceId;
+	}
+
 	// 향수, 검색 필터링 응답 DTO (최종 응답)
 	@Getter
 	@Builder
@@ -99,7 +108,7 @@ public class FragranceResponseDTO {
 		private List<FragranceSearchResult> content;
 		private boolean hasNext;
 	}
-  
+
 }
 
 


### PR DESCRIPTION
## 💡 관련 이슈

#30

## 📢 작업 내용

- 기존 fragrance 관련 service, conver, controller 에서 작업
- repository만 따로 추가
- 현재 로그인한 userId를 jwt 토큰으로 부터 받아와 delete 진행

## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
