### PR TITLE
[Feature] #38 - 향수 전체 리스트 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/config/security/SecurityConfig.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
 	public static final String[] AUTH_WHITELIST = {
 		"/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui.html", "/swagger-ui/**",
 		"/swagger/**", "/users/signup", "/auth/login", "/auth/social/kakao", "/users/reissue",
-		"/health"
+		"/health", "/fragrances/allow/**"
 	};
 	private final JwtAuthenticationFilter JwtAuthenticationFilter;
 	private final JwtExceptionHandlerFilter JwtExceptionHandlerFilter;
@@ -44,7 +44,7 @@ public class SecurityConfig {
 			// 요청 경로별 인증 확인 설정
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(AUTH_WHITELIST).permitAll()
-				.anyRequest().permitAll() // 개발 진행할 때 임시로 풀어두기 -> 나중에 authenticated()로 변경
+				.anyRequest().authenticated() // 개발 진행할 때 임시로 풀어두기 -> 나중에 authenticated()로 변경
 			)
 			// filter 레벨에서 발생하는 예외 핸들러 설정
 			.exceptionHandling(exception -> exception

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
@@ -8,7 +8,8 @@ public interface FragranceService {
 	FragranceResponseDTO.FragranceDetailResult getFragranceDetail(Long fragranceId, Long userId);
 
 	// 향수 검색 API
-	FragranceResponseDTO.FragranceSearchFinalResult searchFragrances(String keyword, int page, int size, Long userId);
+	FragranceResponseDTO.FragranceSearchFinalResult searchFragrances(FragranceRequestDTO.FragranceSearchRequest request,
+		Long userId);
 
 	// 향수 즐겨찾기 등록 API
 	FragranceResponseDTO.FavoriteResponseDTO addFavorite(Long userId, Long fragranceId);
@@ -19,5 +20,9 @@ public interface FragranceService {
 	// 향수 필터링 API
 	FragranceResponseDTO.FragranceSearchFinalResult searchFragrancesByFilter(
 		FragranceRequestDTO.FragranceFilterRequest request, Long userId);
+
+	// 향수 전체 리스트 조회 API
+	FragranceResponseDTO.FragranceSearchFinalResult getFragranceListAll(FragranceRequestDTO.FragranceAllRequest request,
+		Long userId);
 }
 

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
@@ -46,22 +46,23 @@ public class FragranceServiceImpl implements FragranceService {
 		Fragrance fragrance = fragranceRepository.findByIdWithAllDetails(fragranceId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.FRAGRANCE_NOT_FOUND));
 
-		boolean liked = Like(userId, fragranceId);
+		boolean liked = (userId != null) && Like(userId, fragranceId);
 
 		return FragranceConverter.toDetailDto(fragrance, liked);
 	}
 
 	// 향수 검색 API
 	@Override
-	public FragranceResponseDTO.FragranceSearchFinalResult searchFragrances(String keyword, int page, int size,
+	public FragranceResponseDTO.FragranceSearchFinalResult searchFragrances(
+		FragranceRequestDTO.FragranceSearchRequest request,
 		Long userId) {
-		PageRequest pageable = PageRequest.of(page, size);
-		Page<Fragrance> fragrancePage = fragranceRepository.findBySearchKeyword(keyword, pageable);
+		PageRequest pageable = PageRequest.of(request.getPage(), request.getSize());
+		Page<Fragrance> fragrancePage = fragranceRepository.findBySearchKeyword(request.getKeyword(), pageable);
 
 		List<FragranceResponseDTO.FragranceSearchResult> content = fragrancePage.getContent().stream()
 			.map(fragrance -> {
 				// 즐겨찾기 확인
-				boolean liked = Like(userId, fragrance.getId());
+				boolean liked = (userId != null) && Like(userId, fragrance.getId());
 				return FragranceConverter.toSearchResultDto(fragrance, liked);
 			})
 			.collect(Collectors.toList());
@@ -156,7 +157,28 @@ public class FragranceServiceImpl implements FragranceService {
 		List<FragranceResponseDTO.FragranceSearchResult> content = fragrancePage.getContent().stream()
 			.map(fragrance -> {
 				// 즐겨찾기 확인
-				boolean liked = Like(userId, fragrance.getId());
+				boolean liked = (userId != null) && Like(userId, fragrance.getId());
+				return FragranceConverter.toSearchResultDto(fragrance, liked);
+			})
+			.collect(Collectors.toList());
+
+		return FragranceResponseDTO.FragranceSearchFinalResult.builder()
+			.content(content)
+			.hasNext(fragrancePage.hasNext())
+			.build();
+	}
+
+	// 향수 전체 리스트 API
+	@Override
+	public FragranceResponseDTO.FragranceSearchFinalResult getFragranceListAll(
+		FragranceRequestDTO.FragranceAllRequest request, Long userId) {
+		PageRequest pageable = PageRequest.of(request.getPage(), request.getSize());
+		Page<Fragrance> fragrancePage = fragranceRepository.findAll(pageable); // 향수 전체 목록 가져오기
+
+		List<FragranceResponseDTO.FragranceSearchResult> content = fragrancePage.getContent().stream()
+			.map(fragrance -> {
+				// 즐겨찾기 확인
+				boolean liked = (userId != null) && Like(userId, fragrance.getId());
 				return FragranceConverter.toSearchResultDto(fragrance, liked);
 			})
 			.collect(Collectors.toList());

--- a/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
@@ -35,7 +35,7 @@ public class FragranceController {
 	/**
 	 * 향수 상세 API
 	 */
-	@GetMapping("/{fragranceId}")
+	@GetMapping("/allow/{fragranceId}")
 	@Operation(
 		summary = "향수 상세 조회",
 		description = "향수 ID로 상세 정보를 조회하는 API입니다.",
@@ -50,15 +50,16 @@ public class FragranceController {
 	public ResponseEntity<ApiResponse<FragranceResponseDTO.FragranceDetailResult>> getFragranceDetail(
 		@PathVariable("fragranceId") Long fragranceId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		Long userId = (userDetails != null) ? userDetails.getUserId() : null;
 		FragranceResponseDTO.FragranceDetailResult result = fragranceService.getFragranceDetail(fragranceId,
-			userDetails.getUserId());
+			userId);
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
 
 	/**
 	 * 향수 검색 API
 	 */
-	@GetMapping("/search")
+	@GetMapping("/allow/search")
 	@Operation(
 		summary = "향수 키워드 검색 (무한 스크롤)",
 		description = "keyword 로 향수 이름을 검색하고, 페이징 처리된 결과를 반환합니다.",
@@ -76,9 +77,8 @@ public class FragranceController {
 		@Valid @ModelAttribute FragranceRequestDTO.FragranceSearchRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		FragranceResponseDTO.FragranceSearchFinalResult result = fragranceService.searchFragrances(
-			request.getKeyword(), request.getPage(),
-			request.getSize(), userDetails.getUserId());
+		Long userId = (userDetails != null) ? userDetails.getUserId() : null;
+		FragranceResponseDTO.FragranceSearchFinalResult result = fragranceService.searchFragrances(request, userId);
 
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 
@@ -131,7 +131,7 @@ public class FragranceController {
 	/**
 	 * 향수 필터링 API
 	 */
-	@GetMapping("/filter")
+	@GetMapping("/allow/filter")
 	@Operation(
 		summary = "향수 필터링 검색 (무한 스크롤)",
 		description = "필터링을 통해 걸러진 향수 목록을, 페이징 처리된 결과로 반환합니다.",
@@ -160,9 +160,31 @@ public class FragranceController {
 		@Valid @ModelAttribute FragranceRequestDTO.FragranceFilterRequest request,
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
+		Long userId = (userDetails != null) ? userDetails.getUserId() : null;
 		FragranceResponseDTO.FragranceSearchFinalResult result = fragranceService.searchFragrancesByFilter(request,
-			userDetails.getUserId());
+			userId);
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
 
+	/**
+	 * 향수 전체 리스트 API
+	 */
+
+	@GetMapping("/allow/all")
+	@Operation(
+		summary = "향수 전체 리스트 조회",
+		description = "향수 전체 목록을 조회하는 API 입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = FragranceResponseDTO.FragranceSearchResult.class))),
+		}
+	)
+	public ResponseEntity<ApiResponse<FragranceResponseDTO.FragranceSearchFinalResult>> getFragrancesAll(
+		FragranceRequestDTO.FragranceAllRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		Long userId = (userDetails != null) ? userDetails.getUserId() : null;
+		FragranceResponseDTO.FragranceSearchFinalResult result = fragranceService.getFragranceListAll(request,
+			userId);
+		return ResponseEntity.ok(ApiResponse.onSuccess(result));
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceRequestDTO.java
@@ -50,4 +50,15 @@ public class FragranceRequestDTO {
 
 	}
 
+	// 향수 전체 리스트 요청 DTO
+	@Getter
+	@Setter
+	public static class FragranceAllRequest {
+		@ValidPage
+		private int page;
+
+		@ValidSize
+		private int size;
+	}
+
 }


### PR DESCRIPTION
## 💡 관련 이슈

#38 

## 📢 작업 내용

- DB에 저장된 향수 전체 목록을 반환하는 API 구현
- 로그인 기능 없이 향수 검색, 필터링, 상세 페이지 조회, 전체 목록 조회를 가능하게 하기 위해 SecurityConfig 변경
   - 익명 접근 허용 URL 추가 
       - `/fragrances/allow/**`
   - JWT 인증이 동작하도록 수정 
       - `permitAll()` -> `authenticated()`
- `@AuthenticationPrincipal`을 Optional하게 처리

## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [ ]  코드가 정상적으로 컴파일되나요?
- [ ]  이슈 내용을 전부 구현했나요?
- [ ]  작업 기간 내에 개발을 완료했나요?
- [ ]  리뷰어를 선택했나요?
- [ ]  라벨을 지정했나요?
