### PR TITLE
[Feature] #48 - 온보딩 및 사용자 선호 향 수정 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	LOGIN_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4003", "해당 아이디를 가진 사용자가 존재하지 않습니다."),
 	LOGIN_PARSING_FAIL(HttpStatus.BAD_REQUEST, "MEMBER4004", "로그인 DTO 변환을 실패했습니다."),
 	LOGIN_UNKNOWN_ERROR(HttpStatus.BAD_REQUEST, "MEMBER4005", "로그인 중 알 수 없는 오류가 발생했습니다."),
+	NICKNAME_DUPLICATE(HttpStatus.BAD_REQUEST, "MEMBER4006", "이미 사용된 닉네임입니다."),
 
 	// 토큰 에러
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 토큰입니다."),

--- a/src/main/java/PerfumeOnMe/spring/converter/UserNoteConverter.java
+++ b/src/main/java/PerfumeOnMe/spring/converter/UserNoteConverter.java
@@ -1,16 +1,14 @@
 package PerfumeOnMe.spring.converter;
 
 import PerfumeOnMe.spring.domain.Note;
-import PerfumeOnMe.spring.domain.User;
 import PerfumeOnMe.spring.domain.mapping.UserNote;
 
 public class UserNoteConverter {
 
 	// 노트 + 사용자 = 사용자 노트 반환
-	public static UserNote toUserNote(Note note, User user) {
+	public static UserNote toUserNote(Note note) {
 		return UserNote.builder()
 			.note(note)
-			.user(user)
 			.build();
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/converter/UserNoteConverter.java
+++ b/src/main/java/PerfumeOnMe/spring/converter/UserNoteConverter.java
@@ -1,0 +1,16 @@
+package PerfumeOnMe.spring.converter;
+
+import PerfumeOnMe.spring.domain.Note;
+import PerfumeOnMe.spring.domain.User;
+import PerfumeOnMe.spring.domain.mapping.UserNote;
+
+public class UserNoteConverter {
+
+	// 노트 + 사용자 = 사용자 노트 반환
+	public static UserNote toUserNote(Note note, User user) {
+		return UserNote.builder()
+			.note(note)
+			.user(user)
+			.build();
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/domain/User.java
+++ b/src/main/java/PerfumeOnMe/spring/domain/User.java
@@ -14,6 +14,7 @@ import PerfumeOnMe.spring.domain.mapping.Diary;
 import PerfumeOnMe.spring.domain.mapping.UserFragrance;
 import PerfumeOnMe.spring.domain.mapping.UserNote;
 import PerfumeOnMe.spring.domain.mapping.UserTerms;
+import PerfumeOnMe.spring.web.dto.user.UserRequestDTO;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -104,4 +105,17 @@ public class User extends BaseEntity {
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
 	@Builder.Default
 	private List<Workshop> workshopList = new ArrayList<>();
+
+	public void onboarding(UserRequestDTO.Onboarding request) {
+		this.nickname = request.getNickname();
+		this.imageURL = request.getImageURL();
+		this.gender = UserGender.valueOf(request.getGender().toUpperCase());
+		this.age = Age.valueOf(request.getAge().toUpperCase());
+	}
+
+	// 연관관계 편의 메서드
+	public void addUserNote(UserNote userNote) {
+		this.userNoteList.add(userNote);
+		userNote.setUser(this);
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/domain/enums/ChatSender.java
+++ b/src/main/java/PerfumeOnMe/spring/domain/enums/ChatSender.java
@@ -1,5 +1,0 @@
-package PerfumeOnMe.spring.domain.enums;
-
-public enum ChatSender {
-    USER, AI
-}

--- a/src/main/java/PerfumeOnMe/spring/domain/mapping/UserNote.java
+++ b/src/main/java/PerfumeOnMe/spring/domain/mapping/UserNote.java
@@ -41,4 +41,20 @@ public class UserNote extends BaseEntity {
 	@JoinColumn(name = "note_id")
 	private Note note;
 
+	// 연관관계 편의 메서드
+	public void setUser(User user) {
+		if (this.user != null) {
+			user.getUserNoteList().remove(this);
+		}
+		this.user = user;
+		user.getUserNoteList().add(this);
+	}
+
+	public void setNote(Note note) {
+		if (this.note != null) {
+			note.getUserNoteList().remove(this);
+		}
+		this.note = note;
+		note.getUserNoteList().add(this);
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/user/UserRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/user/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 	Optional<User> findUserByLoginId(String loginId);
 
 	Optional<User> findById(Long id);
+
+	Optional<User> findUserByNickname(String nickname);
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/userNote/UserNoteRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/userNote/UserNoteRepository.java
@@ -1,0 +1,8 @@
+package PerfumeOnMe.spring.repository.userNote;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import PerfumeOnMe.spring.domain.mapping.UserNote;
+
+public interface UserNoteRepository extends JpaRepository<UserNote, Long> {
+}

--- a/src/main/java/PerfumeOnMe/spring/repository/userNote/UserNoteRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/userNote/UserNoteRepository.java
@@ -2,7 +2,10 @@ package PerfumeOnMe.spring.repository.userNote;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import PerfumeOnMe.spring.domain.User;
 import PerfumeOnMe.spring.domain.mapping.UserNote;
 
 public interface UserNoteRepository extends JpaRepository<UserNote, Long> {
+
+	void deleteAllByUser(User user);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserService.java
@@ -1,6 +1,7 @@
 package PerfumeOnMe.spring.service.user;
 
 import PerfumeOnMe.spring.config.security.auth.dto.AuthResponseDTO;
+import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
 import PerfumeOnMe.spring.web.dto.user.UserRequestDTO;
 import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,4 +16,6 @@ public interface UserService {
 	String logout(HttpServletRequest request);
 
 	void deleteUser(HttpServletRequest request);
+
+	void onboarding(UserRequestDTO.Onboarding request, CustomUserDetails userDetails);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserService.java
@@ -18,4 +18,6 @@ public interface UserService {
 	void deleteUser(HttpServletRequest request);
 
 	void onboarding(UserRequestDTO.Onboarding request, CustomUserDetails userDetails);
+
+	void updateUserNote(UserRequestDTO.UserNoteUpdate request, CustomUserDetails userDetails);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
@@ -145,7 +145,6 @@ public class UserServiceImpl implements UserService {
 			UserNote userNote = UserNoteConverter.toUserNote(note);
 			userNoteRepository.save(userNote);
 			user.addUserNote(userNote); // 양방향 연관관계만 설정
-			note.getUserNoteList().add(userNote); // 양방향이지만 단방향처럼 사용 중이라 삭제해도 됨
 		});
 	}
 

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
@@ -142,7 +142,7 @@ public class UserServiceImpl implements UserService {
 		noteCategoryIdList.forEach(noteCategoryId -> {
 			Note note = noteRepository.findById(noteCategoryId)
 				.orElseThrow(() -> new GeneralException(ErrorStatus.INVALID_NOTE_ID));
-			UserNote userNote = UserNoteConverter.toUserNote(note, user);
+			UserNote userNote = UserNoteConverter.toUserNote(note);
 			userNoteRepository.save(userNote);
 			user.addUserNote(userNote); // 양방향 연관관계만 설정
 			note.getUserNoteList().add(userNote); // 양방향이지만 단방향처럼 사용 중이라 삭제해도 됨

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package PerfumeOnMe.spring.service.user;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.security.core.userdetails.UserDetails;
@@ -136,6 +137,18 @@ public class UserServiceImpl implements UserService {
 		findUser.ifPresent(userRepository::delete);
 	}
 
+	// 온보딩 요청 정보 설정 메서드
+	public void saveUserNote(User user, List<Long> noteCategoryIdList) {
+		noteCategoryIdList.forEach(noteCategoryId -> {
+			Note note = noteRepository.findById(noteCategoryId)
+				.orElseThrow(() -> new GeneralException(ErrorStatus.INVALID_NOTE_ID));
+			UserNote userNote = UserNoteConverter.toUserNote(note, user);
+			userNoteRepository.save(userNote);
+			user.addUserNote(userNote); // 양방향 연관관계만 설정
+			note.getUserNoteList().add(userNote); // 양방향이지만 단방향처럼 사용 중이라 삭제해도 됨
+		});
+	}
+
 	// 온보딩
 	@Override
 	public void onboarding(UserRequestDTO.Onboarding request, CustomUserDetails userDetails) {
@@ -153,13 +166,22 @@ public class UserServiceImpl implements UserService {
 		findUser.onboarding(request);
 
 		// 온보딩 요청 정보 설정 - noteCategoryId
-		request.getNoteCategoryId().forEach(id -> {
-			Note note = noteRepository.findById(id)
-				.orElseThrow(() -> new GeneralException(ErrorStatus.INVALID_NOTE_ID));
-			UserNote userNote = UserNoteConverter.toUserNote(note, findUser);
-			userNoteRepository.save(userNote);
-			findUser.addUserNote(userNote); // 양방향 연관관계만 설정
-			note.getUserNoteList().add(userNote); // 양방향이지만 단방향처럼 사용 중이라 삭제해도 됨
-		});
+		saveUserNote(findUser, request.getNoteCategoryId());
+	}
+
+	// 사용자 선호 향 수정
+	@Override
+	public void updateUserNote(UserRequestDTO.UserNoteUpdate request, CustomUserDetails userDetails) {
+
+		// 사용자 조회
+		User findUser = userRepository.findUserByLoginId(userDetails.getUsername())
+			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+
+		// 사용자 선호 노트 정보 삭제
+		userNoteRepository.deleteAllByUser(findUser);
+		findUser.getUserNoteList().clear();
+
+		// 온보딩 요청 정보 설정 - noteCategoryId
+		saveUserNote(findUser, request.getNoteCategoryId());
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
@@ -18,9 +18,14 @@ import PerfumeOnMe.spring.config.security.auth.provider.JwtTokenProvider;
 import PerfumeOnMe.spring.config.security.auth.token.JwtAuthenticationToken;
 import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
 import PerfumeOnMe.spring.converter.UserConverter;
+import PerfumeOnMe.spring.converter.UserNoteConverter;
+import PerfumeOnMe.spring.domain.Note;
 import PerfumeOnMe.spring.domain.User;
 import PerfumeOnMe.spring.domain.enums.Social;
+import PerfumeOnMe.spring.domain.mapping.UserNote;
+import PerfumeOnMe.spring.repository.note.NoteRepository;
 import PerfumeOnMe.spring.repository.user.UserRepository;
+import PerfumeOnMe.spring.repository.userNote.UserNoteRepository;
 import PerfumeOnMe.spring.web.dto.user.UserRequestDTO;
 import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,6 +43,8 @@ public class UserServiceImpl implements UserService {
 	private final RefreshTokenManager refreshTokenManager;
 	private final LogoutAccessTokenManager logoutAccessTokenManager;
 	private final UserDetailsService userDetailsService;
+	private final UserNoteRepository userNoteRepository;
+	private final NoteRepository noteRepository;
 
 	// 사용자 회원가입
 	@Override
@@ -127,5 +134,32 @@ public class UserServiceImpl implements UserService {
 		String loginId = logout(request);
 		Optional<User> findUser = userRepository.findUserByLoginId(loginId);
 		findUser.ifPresent(userRepository::delete);
+	}
+
+	// 온보딩
+	@Override
+	public void onboarding(UserRequestDTO.Onboarding request, CustomUserDetails userDetails) {
+
+		// 닉네임 중복 검증
+		if (userRepository.findUserByNickname(request.getNickname()).isPresent()) {
+			throw new GeneralException(ErrorStatus.NICKNAME_DUPLICATE);
+		}
+
+		// 사용자 조회
+		User findUser = userRepository.findUserByLoginId(userDetails.getUsername())
+			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+
+		// 온보딩 요청 정보 설정 - nickname, imageURL, gender, age
+		findUser.onboarding(request);
+
+		// 온보딩 요청 정보 설정 - noteCategoryId
+		request.getNoteCategoryId().forEach(id -> {
+			Note note = noteRepository.findById(id)
+				.orElseThrow(() -> new GeneralException(ErrorStatus.INVALID_NOTE_ID));
+			UserNote userNote = UserNoteConverter.toUserNote(note, findUser);
+			userNoteRepository.save(userNote);
+			findUser.addUserNote(userNote); // 양방향 연관관계만 설정
+			note.getUserNoteList().add(userNote); // 양방향이지만 단방향처럼 사용 중이라 삭제해도 됨
+		});
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/validation/annotation/ExistUserAge.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/annotation/ExistUserAge.java
@@ -1,0 +1,23 @@
+package PerfumeOnMe.spring.validation.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import PerfumeOnMe.spring.validation.validator.ExistUserAgeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ExistUserAgeValidator.class)
+@Documented
+public @interface ExistUserAge {
+	String message() default "TEENAGER, TWENTIES, THIRTIES, FORTIES, NONE 중 하나만 입력할 수 있습니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/PerfumeOnMe/spring/validation/annotation/ExistUserGender.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/annotation/ExistUserGender.java
@@ -1,0 +1,23 @@
+package PerfumeOnMe.spring.validation.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import PerfumeOnMe.spring.validation.validator.ExistUserGenderValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ExistUserGenderValidator.class)
+@Documented
+public @interface ExistUserGender {
+	String message() default "MALE, FEMALE, NONE 중 하나만 입력할 수 있습니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/PerfumeOnMe/spring/validation/annotation/ValidUserNote.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/annotation/ValidUserNote.java
@@ -1,0 +1,23 @@
+package PerfumeOnMe.spring.validation.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import PerfumeOnMe.spring.validation.validator.ValidUserNoteValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidUserNoteValidator.class)
+@Documented
+public @interface ValidUserNote {
+	String message() default "3개의 숫자가 입력돼야 합니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/PerfumeOnMe/spring/validation/validator/ExistUserAgeValidator.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/validator/ExistUserAgeValidator.java
@@ -1,0 +1,26 @@
+package PerfumeOnMe.spring.validation.validator;
+
+import PerfumeOnMe.spring.domain.enums.Age;
+import PerfumeOnMe.spring.validation.annotation.ExistUserAge;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ExistUserAgeValidator implements ConstraintValidator<ExistUserAge, String> {
+
+	@Override
+	public void initialize(ExistUserAge constraintAnnotation) {
+		ConstraintValidator.super.initialize(constraintAnnotation);
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+		if (value == null || value.isEmpty())
+			return false;
+		try {
+			Age.valueOf(value.toUpperCase());
+			return true;
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/validation/validator/ExistUserGenderValidator.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/validator/ExistUserGenderValidator.java
@@ -1,0 +1,26 @@
+package PerfumeOnMe.spring.validation.validator;
+
+import PerfumeOnMe.spring.domain.enums.UserGender;
+import PerfumeOnMe.spring.validation.annotation.ExistUserGender;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ExistUserGenderValidator implements ConstraintValidator<ExistUserGender, String> {
+
+	@Override
+	public void initialize(ExistUserGender constraintAnnotation) {
+		ConstraintValidator.super.initialize(constraintAnnotation);
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if (value == null || value.isEmpty())
+			return false;
+		try {
+			UserGender.valueOf(value.toUpperCase());
+			return true;
+		} catch (IllegalArgumentException e) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/validation/validator/ValidUserNoteValidator.java
+++ b/src/main/java/PerfumeOnMe/spring/validation/validator/ValidUserNoteValidator.java
@@ -1,0 +1,20 @@
+package PerfumeOnMe.spring.validation.validator;
+
+import java.util.List;
+
+import PerfumeOnMe.spring.validation.annotation.ValidUserNote;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ValidUserNoteValidator implements ConstraintValidator<ValidUserNote, List<Long>> {
+
+	@Override
+	public void initialize(ValidUserNote constraintAnnotation) {
+		ConstraintValidator.super.initialize(constraintAnnotation);
+	}
+
+	@Override
+	public boolean isValid(List<Long> longs, ConstraintValidatorContext constraintValidatorContext) {
+		return longs.size() == 3;
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -110,6 +111,22 @@ public class UserController {
 	public ResponseEntity<ApiResponse<Object>> onboarding(@Valid @RequestBody UserRequestDTO.Onboarding request,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		userService.onboarding(request, userDetails);
+		return ResponseEntity.ok().body(ApiResponse.onSuccess(null));
+	}
+
+	@PatchMapping("/notes")
+	@Operation(
+		summary = "선호 향 수정 API",
+		description = "사용자의 선호하는 향 리스트를 입력받아 수정하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4003", description = "해당 아이디를 가진 사용자가 존재하지 않습니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FILTER4003", description = "유효하지 않은 노트 ID 입니다."),
+		}
+	)
+	public ResponseEntity<ApiResponse<Object>> updateUserNote(@Valid @RequestBody UserRequestDTO.UserNoteUpdate request,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		userService.updateUserNote(request, userDetails);
 		return ResponseEntity.ok().body(ApiResponse.onSuccess(null));
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/UserController.java
@@ -2,6 +2,7 @@ package PerfumeOnMe.spring.web.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import PerfumeOnMe.spring.apiPayload.ApiResponse;
 import PerfumeOnMe.spring.apiPayload.code.status.SuccessStatus;
 import PerfumeOnMe.spring.config.security.auth.dto.AuthResponseDTO;
+import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
 import PerfumeOnMe.spring.service.user.UserService;
 import PerfumeOnMe.spring.web.dto.user.UserRequestDTO;
 import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
@@ -91,6 +93,23 @@ public class UserController {
 	)
 	public ResponseEntity<ApiResponse<Object>> deleteUser(HttpServletRequest request) {
 		userService.deleteUser(request);
+		return ResponseEntity.ok().body(ApiResponse.onSuccess(null));
+	}
+
+	@PostMapping("/onboarding")
+	@Operation(
+		summary = "온보딩 API",
+		description = "사용자의 닉네임, 프로필 사진, 성별, 연령대, 선호하는 향 리스트를 입력받아 저장하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4003", description = "해당 아이디를 가진 사용자가 존재하지 않습니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER4006", description = "이미 사용된 닉네임입니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "FILTER4003", description = "유효하지 않은 노트 ID 입니다."),
+		}
+	)
+	public ResponseEntity<ApiResponse<Object>> onboarding(@Valid @RequestBody UserRequestDTO.Onboarding request,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		userService.onboarding(request, userDetails);
 		return ResponseEntity.ok().body(ApiResponse.onSuccess(null));
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/user/UserRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/user/UserRequestDTO.java
@@ -67,4 +67,14 @@ public class UserRequestDTO {
 		@ValidUserNote
 		private List<Long> noteCategoryId;
 	}
+
+	// 사용자 선호 향 수정
+	@Getter
+	@NoArgsConstructor
+	public static class UserNoteUpdate {
+		@NotNull
+		@Schema(description = "사용자가 설정한 선호하는 향", example = "[5,11,2]")
+		@ValidUserNote
+		private List<Long> noteCategoryId;
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/user/UserRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/user/UserRequestDTO.java
@@ -1,13 +1,20 @@
 package PerfumeOnMe.spring.web.dto.user;
 
+import java.util.List;
+
+import PerfumeOnMe.spring.validation.annotation.ExistUserAge;
+import PerfumeOnMe.spring.validation.annotation.ExistUserGender;
+import PerfumeOnMe.spring.validation.annotation.ValidUserNote;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class UserRequestDTO {
 
+	// 회원가입
 	@Getter
 	@NoArgsConstructor
 	public static class Signup {
@@ -32,5 +39,32 @@ public class UserRequestDTO {
 			message = "비밀번호는 영어 대소문자, 숫자, 특수문자(@$!%*?&#)만 허용되며, 공백 없이 8자 이상 20자 이하로 입력해주세요."
 		)
 		private String password;
+	}
+
+	// 온보딩
+	@Getter
+	@NoArgsConstructor
+	public static class Onboarding {
+		@NotBlank
+		@Schema(description = "사용자가 입력한 닉네임", example = "리버")
+		@Pattern(
+			regexp = "^[가-힣a-zA-Z0-9]{2,10}$",
+			message = "닉네임은 한글, 영어 대소문자, 숫자만 허용되며, 공백 없이 2자 이상 10자 이하로 입력해주세요."
+		)
+		private String nickname;
+		@Schema(description = "사용자가 설정한 사진 URL", example = "https://...")
+		private String imageURL;
+		@NotNull
+		@Schema(description = "사용자가 설정한 성별", example = "FEMALE")
+		@ExistUserGender
+		private String gender;
+		@NotNull
+		@Schema(description = "사용자가 설정한 연령대", example = "TWENTIES")
+		@ExistUserAge
+		private String age;
+		@NotNull
+		@Schema(description = "사용자가 설정한 선호하는 향", example = "[5,11,2]")
+		@ValidUserNote
+		private List<Long> noteCategoryId;
 	}
 }


### PR DESCRIPTION
## 💡 관련 이슈

#48 

## 📢 작업 내용

- **온보딩 API 구현**
  - DTO, Controller, Service, Converter 추가
  - 요청 DTO 검증 Validator 추가
- **사용자 선호 향 수정 API 구현**
  - DTO, Controller, Service, Converter 추가
  - 온보딩 API와 중복되는 코드를 메서드(saveUserNote)로 분리

## 🗨️ 리뷰 요구사항(선택)

- .

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
