### PR TITLE
[Feature] #65 - 다이어리 수정 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -66,6 +66,10 @@ public enum ErrorStatus implements BaseErrorCode {
 	PROMPT_LOADING_FAIL(HttpStatus.BAD_REQUEST, "CHATBOT4002", "프롬프트 로딩에 실패하였습니다."),
 	REQUIRED_MESSAGES(HttpStatus.BAD_REQUEST, "CHATBOT4003", "메세지를 입력하세요."),
 
+	// 다이어리 에러
+	DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4001", "해당 다이어리를 찾을 수 없습니다."),
+	USER_DIARY_FORBIDDEN(HttpStatus.BAD_REQUEST, "DIARY4002", "다이어리 소유자의 요청이 아닙니다."),
+
 	// 예시,,,
 	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
 

--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/SuccessStatus.java
@@ -13,7 +13,8 @@ public enum SuccessStatus implements BaseCode {
 
 	// 일반적인 응답
 	_OK(HttpStatus.OK, "COMMON200", "성공입니다."),
-	_CREATED(HttpStatus.OK, "COMMON201", "리소스를 성공적으로 생성했습니다.");
+	_CREATED(HttpStatus.OK, "COMMON201", "리소스를 성공적으로 생성했습니다."),
+	DIARY_UPDATED(HttpStatus.OK, "DIARY200", "다이어리가 수정되었습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/PerfumeOnMe/spring/domain/mapping/Diary.java
+++ b/src/main/java/PerfumeOnMe/spring/domain/mapping/Diary.java
@@ -51,4 +51,10 @@ public class Diary extends BaseEntity {
 
 	@Column(columnDefinition = "TEXT", nullable = false)
 	private String content;
+
+	// 다이어리 수정하는 메서드
+	public void updateFragranceNameAndContent(String fragranceName, String content) {
+		this.fragranceName = fragranceName;
+		this.content = content;
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryService.java
@@ -7,4 +7,7 @@ public interface DiaryService {
 
 	// 다이어리 추가 API
 	DiaryResponseDTO.AddDiaryResponse addDiary(Long userId, DiaryRequestDTO.AddDiaryRequest addDiaryRequest);
+
+	// 다이어리 수정 API
+	void updateDiary(Long userId, Long diaryId, DiaryRequestDTO.UpdateDiaryRequest updateDiaryRequest);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryServiceImpl.java
@@ -38,4 +38,22 @@ public class DiaryServiceImpl implements DiaryService {
 		diaryRepository.save(diary);
 		return DiaryConverter.addDiaryResponseDTO(diary);
 	}
+
+	// 다이어리 수정 API
+	@Override
+	public void updateDiary(Long userId, Long diaryId, DiaryRequestDTO.UpdateDiaryRequest updateDiaryRequest) {
+		// 다이어리 존재 여부 확인
+		Diary diary = diaryRepository.findById(diaryId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.DIARY_NOT_FOUND));
+
+		// 다이어리 소유자 확인
+		if (!diary.getUser().getId().equals(userId)) {
+			throw new GeneralException(ErrorStatus.USER_DIARY_FORBIDDEN);
+		}
+
+		diary.updateFragranceNameAndContent(updateDiaryRequest.getFragranceName(), updateDiaryRequest.getContent());
+
+		// 다이어리 저장
+		diaryRepository.save(diary);
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/DiaryController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/DiaryController.java
@@ -2,12 +2,15 @@ package PerfumeOnMe.spring.web.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import PerfumeOnMe.spring.apiPayload.ApiResponse;
+import PerfumeOnMe.spring.apiPayload.code.status.SuccessStatus;
 import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
 import PerfumeOnMe.spring.service.Diary.DiaryService;
 import PerfumeOnMe.spring.web.dto.diary.DiaryRequestDTO;
@@ -42,5 +45,24 @@ public class DiaryController {
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		DiaryResponseDTO.AddDiaryResponse result = diaryService.addDiary(userDetails.getUserId(), request);
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
+	}
+
+	// 다이어리 수정 API
+	@PatchMapping("/{diaryId}/update")
+	@Operation(
+		summary = "다이어리 수정",
+		description = "다이어리를 수정하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "다이어리가 수정되었습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4001", description = "해당 다이어리를 찾을 수 없습니다."),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4002", description = "다이어리 소유자의 요청이 아닙니다.")
+		}
+	)
+	public ResponseEntity<ApiResponse<Void>> updateDiary(
+		@PathVariable Long diaryId,
+		@RequestBody @Valid DiaryRequestDTO.UpdateDiaryRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		diaryService.updateDiary(userDetails.getUserId(), diaryId, request);
+		return ResponseEntity.ok(ApiResponse.of(SuccessStatus.DIARY_UPDATED, null));
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/diary/DiaryRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/diary/DiaryRequestDTO.java
@@ -16,4 +16,12 @@ public class DiaryRequestDTO {
 		private LocalDate date;
 	}
 
+	// 다이어리 수정 요청 DTO
+	@Getter
+	@Setter
+	public static class UpdateDiaryRequest {
+		private String fragranceName;
+		private String content;
+	}
+
 }


### PR DESCRIPTION
## 💡 관련 이슈

#65

## 📢 작업 내용

- 입력받은 diaryId에 해당하는 다이어리 수정
- Diary 엔티티에 향수이름, 내용 수정하는 별도의 메서드 추가

## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
