### PR TITLE
[Feature] #69 - 일별 다이어리 상세 조회 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -69,6 +69,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	// 다이어리 에러
 	DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4001", "해당 다이어리를 찾을 수 없습니다."),
 	USER_DIARY_FORBIDDEN(HttpStatus.BAD_REQUEST, "DIARY4002", "다이어리 소유자의 요청이 아닙니다."),
+	USER_DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4003", "해당 날짜에 해당하는 다이어리를 찾을 수 없습니다."),
 
 	// 예시,,,
 	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");

--- a/src/main/java/PerfumeOnMe/spring/repository/diary/DiaryRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/diary/DiaryRepository.java
@@ -1,5 +1,7 @@
 package PerfumeOnMe.spring.repository.diary;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +11,6 @@ import PerfumeOnMe.spring.domain.mapping.Diary;
 public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryRepositoryCustom {
 
 	Optional<Diary> findById(Long id);
+
+	List<Diary> findAllByUserIdAndDate(Long userId, LocalDate date);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryService.java
@@ -1,5 +1,8 @@
 package PerfumeOnMe.spring.service.Diary;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import PerfumeOnMe.spring.web.dto.diary.DiaryRequestDTO;
 import PerfumeOnMe.spring.web.dto.diary.DiaryResponseDTO;
 
@@ -13,4 +16,7 @@ public interface DiaryService {
 
 	// 다이어리 삭제 API
 	void deleteDiary(Long userId, Long diaryId);
+
+	// 일별 다이어리 상세 조회 API
+	List<DiaryResponseDTO.SearchDailyDiaryResponse> searchDailyDiary(Long userId, LocalDate date);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryServiceImpl.java
@@ -1,5 +1,8 @@
 package PerfumeOnMe.spring.service.Diary;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -71,4 +74,19 @@ public class DiaryServiceImpl implements DiaryService {
 
 		diaryRepository.delete(diary);
 	}
+
+	// 일별 다이어리 상세 조회 API
+	@Override
+	public List<DiaryResponseDTO.SearchDailyDiaryResponse> searchDailyDiary(Long userId, LocalDate date) {
+		// 해당 날짜의 다이어리들 조회
+		List<Diary> diaries = diaryRepository.findAllByUserIdAndDate(userId, date);
+
+		if (diaries.isEmpty()) {
+			throw new GeneralException(ErrorStatus.USER_DIARY_NOT_FOUND);
+		}
+
+		return DiaryResponseDTO.SearchDailyDiaryResponse.fromEntityList(diaries);
+	}
 }
+
+

--- a/src/main/java/PerfumeOnMe/spring/web/controller/DiaryController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/DiaryController.java
@@ -1,8 +1,12 @@
 package PerfumeOnMe.spring.web.controller;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +21,7 @@ import PerfumeOnMe.spring.service.Diary.DiaryService;
 import PerfumeOnMe.spring.web.dto.diary.DiaryRequestDTO;
 import PerfumeOnMe.spring.web.dto.diary.DiaryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -83,5 +88,26 @@ public class DiaryController {
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		diaryService.deleteDiary(userDetails.getUserId(), diaryId);
 		return ResponseEntity.ok(ApiResponse.of(SuccessStatus.DIARY_DELETED, null));
+	}
+
+	// 일별 다이어리 상세 조회 API
+	@GetMapping("/daily/{date}")
+	@Operation(
+		summary = "일별 다이어리 상세 조회",
+		description = "일별 다이어리를 상세 조회하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "다이어리가 조회되었습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = DiaryResponseDTO.SearchDailyDiaryResponse.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4003", description = "해당 날짜에 해당하는 다이어리를 찾을 수 없습니다.")
+		}
+	)
+	public ResponseEntity<ApiResponse<List<DiaryResponseDTO.SearchDailyDiaryResponse>>> searchDailyDiary(
+		@Parameter(
+			description = "조회할 날짜 (예: 2025-07-17)"
+		)
+		@PathVariable LocalDate date,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		List<DiaryResponseDTO.SearchDailyDiaryResponse> result = diaryService.searchDailyDiary(userDetails.getUserId(),
+			date);
+		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/diary/DiaryResponseDTO.java
@@ -1,7 +1,10 @@
 package PerfumeOnMe.spring.web.dto.diary;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
+import PerfumeOnMe.spring.domain.mapping.Diary;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +20,31 @@ public class DiaryResponseDTO {
 	public static class AddDiaryResponse {
 		private Long id;
 		private LocalDate date;
+	}
+
+	// 일별 다이어리 상세 조회 응답 DTO
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class SearchDailyDiaryResponse {
+		private Long id;
+		private LocalDate date;
+		private String content;
+		private LocalDateTime createdAt;
+		private LocalDateTime updatedAt;
+
+		public static List<SearchDailyDiaryResponse> fromEntityList(List<Diary> diaries) {
+			return diaries.stream()
+				.map(diary -> SearchDailyDiaryResponse.builder()
+					.id(diary.getId())
+					.date(diary.getDate())
+					.content(diary.getContent())
+					.createdAt(diary.getCreatedAt())
+					.updatedAt(diary.getUpdatedAt())
+					.build())
+				.toList();
+		}
 	}
 
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/diary/DiaryResponseDTO.java
@@ -29,6 +29,7 @@ public class DiaryResponseDTO {
 	@NoArgsConstructor
 	public static class SearchDailyDiaryResponse {
 		private Long id;
+		private String fragranceName;
 		private LocalDate date;
 		private String content;
 		private LocalDateTime createdAt;
@@ -38,6 +39,7 @@ public class DiaryResponseDTO {
 			return diaries.stream()
 				.map(diary -> SearchDailyDiaryResponse.builder()
 					.id(diary.getId())
+					.fragranceName(diary.getFragranceName())
 					.date(diary.getDate())
 					.content(diary.getContent())
 					.createdAt(diary.getCreatedAt())


### PR DESCRIPTION
## 💡 관련 이슈

#69

## 📢 작업 내용

- 'YYYY-MM-DD' 형식의 date를 입력받아 해당하는 다이어리 전체 조회
- 조회 결과를 SearchDailyDiaryResponse DTO로 매핑
- 다이어리 소유자 확인 로직 적용

## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
