### PR TITLE
[Feature] 월별 다이어리 조회 API 구현 (#71)

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -70,6 +70,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4001", "해당 다이어리를 찾을 수 없습니다."),
 	USER_DIARY_FORBIDDEN(HttpStatus.BAD_REQUEST, "DIARY4002", "다이어리 소유자의 요청이 아닙니다."),
 	USER_DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4003", "해당 날짜에 해당하는 다이어리를 찾을 수 없습니다."),
+	MONTH_DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4004", "해당 월에 작성된 다이어리가 없습니다."),
 
 	// 예시,,,
 	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");

--- a/src/main/java/PerfumeOnMe/spring/repository/diary/DiaryRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/diary/DiaryRepository.java
@@ -13,4 +13,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long>, DiaryReposi
 	Optional<Diary> findById(Long id);
 
 	List<Diary> findAllByUserIdAndDate(Long userId, LocalDate date);
+
+	List<Diary> findAllByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryService.java
@@ -19,4 +19,8 @@ public interface DiaryService {
 
 	// 일별 다이어리 상세 조회 API
 	List<DiaryResponseDTO.SearchDailyDiaryResponse> searchDailyDiary(Long userId, LocalDate date);
+
+	// 월별 다이어리 조회 API
+	List<DiaryResponseDTO.SearchMonthlyDiaryResponse> searchMonthlyDiary(Long userId, LocalDate startDate,
+		LocalDate endDate);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/Diary/DiaryServiceImpl.java
@@ -87,6 +87,20 @@ public class DiaryServiceImpl implements DiaryService {
 
 		return DiaryResponseDTO.SearchDailyDiaryResponse.fromEntityList(diaries);
 	}
+
+	// 월별 다이어리 조회 API
+	@Override
+	public List<DiaryResponseDTO.SearchMonthlyDiaryResponse> searchMonthlyDiary(Long userId, LocalDate startDate,
+		LocalDate endDate) {
+		// 해당 월의 다이어리들 조회
+		List<Diary> diaries = diaryRepository.findAllByUserIdAndDateBetween(userId, startDate, endDate);
+
+		if (diaries.isEmpty()) {
+			throw new GeneralException(ErrorStatus.MONTH_DIARY_NOT_FOUND);
+		}
+
+		return DiaryResponseDTO.SearchMonthlyDiaryResponse.fromEntityList(diaries);
+	}
 }
 
 

--- a/src/main/java/PerfumeOnMe/spring/web/controller/DiaryController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/DiaryController.java
@@ -110,4 +110,27 @@ public class DiaryController {
 			date);
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
+
+	// 월별 다이어리 조회 API
+	@GetMapping("/monthly/{year}/{month}")
+	@Operation(
+		summary = "월별 다이어리 조회",
+		description = "월별 다이어리를 조회하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "다이어리가 조회되었습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = DiaryResponseDTO.SearchMonthlyDiaryResponse.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "DIARY4004", description = "해당 월에 작성된 다이어리가 없습니다.")
+		}
+	)
+	public ResponseEntity<ApiResponse<List<DiaryResponseDTO.SearchMonthlyDiaryResponse>>> searchMonthlyDiary(
+		@PathVariable Integer year,
+		@PathVariable Integer month,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		LocalDate startDate = LocalDate.of(year, month, 1);
+		LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+		List<DiaryResponseDTO.SearchMonthlyDiaryResponse> result =
+			diaryService.searchMonthlyDiary(userDetails.getUserId(), startDate, endDate);
+		return ResponseEntity.ok(ApiResponse.onSuccess(result));
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/diary/DiaryResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/diary/DiaryResponseDTO.java
@@ -49,4 +49,27 @@ public class DiaryResponseDTO {
 		}
 	}
 
+	// 월별 다이어리 조회 응답 DTO
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class SearchMonthlyDiaryResponse {
+		private Long id;
+		private String fragranceName;
+		private LocalDate date;
+		private String content;
+
+		public static List<SearchMonthlyDiaryResponse> fromEntityList(List<Diary> diaries) {
+			return diaries.stream()
+				.map(diary -> SearchMonthlyDiaryResponse.builder()
+					.id(diary.getId())
+					.fragranceName(diary.getFragranceName())
+					.date(diary.getDate())
+					.content(diary.getContent())
+					.build())
+				.toList();
+		}
+	}
+
 }


### PR DESCRIPTION
## 💡 관련 이슈

#71

## 📢 작업 내용

- year, month를 입력받아 생성한 시작일, 말일을 기준으로 해당되는 범위의 다이어리 조회
- 조회된 다이어리 목록을 SearchMonthlyDiaryResponse DTO로 변환하여 응답
- 사용자 ID와 날짜 범위로 다이어리 목록 조회하는 쿼리 메서드 구현 (findAllByUserIdAndDateBetween)

## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
