### PR TITLE
[Feature] #73 - PBTI 결과 조회 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -72,6 +72,10 @@ public enum ErrorStatus implements BaseErrorCode {
 	USER_DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4003", "해당 날짜에 해당하는 다이어리를 찾을 수 없습니다."),
 	MONTH_DIARY_NOT_FOUND(HttpStatus.BAD_REQUEST, "DIARY4004", "해당 월에 작성된 다이어리가 없습니다."),
 
+	// PBTI 에러
+	CALL_WEBCLIENT_ERROR(HttpStatus.BAD_REQUEST, "PBTI4001", "WebClient 호출 과정에서 에러가 발생했습니다."),
+	JSON_PARSING_ERROR(HttpStatus.BAD_REQUEST, "PBTI4002", "GPT 응답 Json 파싱 과정에서 에러가 발생했습니다."),
+
 	// 예시,,,
 	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
 

--- a/src/main/java/PerfumeOnMe/spring/config/WebClientConfig.java
+++ b/src/main/java/PerfumeOnMe/spring/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package PerfumeOnMe.spring.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+	@Bean
+	public WebClient webClient() {
+		return WebClient.builder().build();
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/domain/PBTI.java
+++ b/src/main/java/PerfumeOnMe/spring/domain/PBTI.java
@@ -45,8 +45,29 @@ public class PBTI extends BaseEntity {
 	@Column(nullable = false, length = 50)
 	private String savedName;
 
-	@Column(columnDefinition = "json", nullable = false)
-	private String answers;
+	@Column(nullable = false, length = 150)
+	private String qOne;
+
+	@Column(nullable = false, length = 150)
+	private String qTwo;
+
+	@Column(nullable = false, length = 150)
+	private String qThree;
+
+	@Column(nullable = false, length = 150)
+	private String qFour;
+
+	@Column(nullable = false, length = 150)
+	private String qFive;
+
+	@Column(nullable = false, length = 150)
+	private String qSix;
+
+	@Column(nullable = false, length = 150)
+	private String qSeven;
+
+	@Column(nullable = false, length = 150)
+	private String qEight;
 
 	@Column(columnDefinition = "text", nullable = false)
 	private String recommendation;
@@ -55,16 +76,16 @@ public class PBTI extends BaseEntity {
 	private String keywords;
 
 	@Column(columnDefinition = "json", nullable = false)
-	private String style;
+	private String perfumeStyle;
 
 	@Column(columnDefinition = "json", nullable = false)
-	private String scentProfile;
+	private String scentPoint;
 
 	@Column(columnDefinition = "text", nullable = false)
 	private String summary;
 
 	@Column(columnDefinition = "json", nullable = false)
-	private String perfumes;
+	private String perfumeRecommend;
 
 	@OneToMany(mappedBy = "pbti", cascade = CascadeType.ALL)
 	@Builder.Default

--- a/src/main/java/PerfumeOnMe/spring/repository/pbti/PbtiRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/pbti/PbtiRepository.java
@@ -1,0 +1,9 @@
+package PerfumeOnMe.spring.repository.pbti;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import PerfumeOnMe.spring.domain.PBTI;
+
+public interface PbtiRepository extends JpaRepository<PBTI, Long> {
+
+}

--- a/src/main/java/PerfumeOnMe/spring/service/diary/DiaryService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/diary/DiaryService.java
@@ -1,4 +1,4 @@
-package PerfumeOnMe.spring.service.Diary;
+package PerfumeOnMe.spring.service.diary;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/PerfumeOnMe/spring/service/diary/DiaryServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/diary/DiaryServiceImpl.java
@@ -1,4 +1,4 @@
-package PerfumeOnMe.spring.service.Diary;
+package PerfumeOnMe.spring.service.diary;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/PerfumeOnMe/spring/service/openAi/OpenAiApiClient.java
+++ b/src/main/java/PerfumeOnMe/spring/service/openAi/OpenAiApiClient.java
@@ -8,6 +8,8 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
+import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
 import PerfumeOnMe.spring.web.dto.Pbti.ChatGptRequest;
 import PerfumeOnMe.spring.web.dto.Pbti.ChatGptResponse;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +35,7 @@ public class OpenAiApiClient {
 			.bodyValue(request)
 			.retrieve()
 			.bodyToMono(ChatGptResponse.class)
-			.onErrorResume(e -> Mono.error(new RuntimeException("OpenAI 요청 실패: " + e.getMessage())))
+			.onErrorResume(e -> Mono.error(new GeneralException(ErrorStatus.CALL_WEBCLIENT_ERROR)))
 			.block();
 	}
 

--- a/src/main/java/PerfumeOnMe/spring/service/openAi/OpenAiApiClient.java
+++ b/src/main/java/PerfumeOnMe/spring/service/openAi/OpenAiApiClient.java
@@ -1,0 +1,54 @@
+package PerfumeOnMe.spring.service.openAi;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import PerfumeOnMe.spring.web.dto.Pbti.ChatGptRequest;
+import PerfumeOnMe.spring.web.dto.Pbti.ChatGptResponse;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class OpenAiApiClient {
+
+	private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+	private final WebClient webClient;
+
+	@Value("${openai.api-key}")
+	private String openAiApiKey;
+	@Value("${openai.model}")
+	private String model; // OpenAI 모델 이름 - gpt-4
+
+	public ChatGptResponse getChatGptResponse(ChatGptRequest request) {
+		return webClient.post()
+			.uri(OPENAI_API_URL)
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + openAiApiKey)
+			.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.bodyValue(request)
+			.retrieve()
+			.bodyToMono(ChatGptResponse.class)
+			.onErrorResume(e -> Mono.error(new RuntimeException("OpenAI 요청 실패: " + e.getMessage())))
+			.block();
+	}
+
+	public String callChatGPT(String prompt) {
+		ChatGptRequest request = ChatGptRequest.builder()
+			.model(model)
+			.temperature(0.7)
+			.messages(List.of(
+				new ChatGptRequest.Message("user", prompt)
+			))
+			.build();
+
+		ChatGptResponse response = getChatGptResponse(request);
+
+		return response.getChoices().get(0).getMessage().getContent();
+	}
+
+}

--- a/src/main/java/PerfumeOnMe/spring/service/openAi/OpenAiService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/openAi/OpenAiService.java
@@ -1,0 +1,8 @@
+package PerfumeOnMe.spring.service.openAi;
+
+public interface OpenAiService {
+
+	// PBTI 구조화된 응답 반환
+	String getStructuredResponse(String prompt);
+}
+

--- a/src/main/java/PerfumeOnMe/spring/service/openAi/OpenAiServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/openAi/OpenAiServiceImpl.java
@@ -1,0 +1,19 @@
+package PerfumeOnMe.spring.service.openAi;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OpenAiServiceImpl implements OpenAiService {
+
+	private final OpenAiApiClient openAiApiClient; // GPT API 호출용 클라이언트
+
+	@Override
+	public String getStructuredResponse(String prompt) {
+		return openAiApiClient.callChatGPT(prompt); // 실제 GPT 호출 로직 구현
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/service/openAi/PromptBuilder.java
+++ b/src/main/java/PerfumeOnMe/spring/service/openAi/PromptBuilder.java
@@ -1,0 +1,85 @@
+package PerfumeOnMe.spring.service.openAi;
+
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiRequestDTO;
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiResponseDTO;
+
+public class PromptBuilder {
+
+	public static String buildPromptFromRequest(PbtiRequestDTO.PbtiQuestionRequest request,
+		PbtiResponseDTO.PbtiResult result) {
+
+		String keywordString = String.join(", ",
+			result.getKeyword1(),
+			result.getKeyword2(),
+			result.getKeyword3(),
+			result.getKeyword4()
+		);
+
+		return String.format("""	
+				아래는 사용자가 향수 성향 테스트에 응답한 결과입니다.:
+				Q1: %s
+				Q2: %s
+				Q3: %s
+				Q4: %s
+				Q5: %s
+				Q6: %s
+				Q7: %s
+				Q8: %s
+				
+				이 사용자는 다음과 같은 향수 성향 키워드를 가지고 있습니다:
+				%s
+				
+				이 키워드 각각에 대해 향수 성향 기반 설명(keywordDescription)을 작성하세요. 각 키워드는 다음 JSON 형식의 "keywords" 필드에 배열로 포함되어야 합니다.
+				또한 각 keywords 배열의 "keyword"는 위의 향수 성향 키워드에서 그대로 사용하세요. GPT가 임의로 바꾸지 마세요.
+				
+				추가로 각 질문에 대한 사용자의 답변을 아래 JSON 포맷에 맞게 분석하여 출력하세요. JSON 이외의 설명은 절대 하지 말고, JSON 데이터만 정확하게 출력해주세요.:
+				
+				- "recommendation"은 '당신은' 으로 시작되도록 하세요.
+				- "scentPoint" 배열 내의 "category"와 "perfumeStyle" 내 "notes" 배열 내의 "category"는 한국어로 응답해주세요.
+				- "scentPoint" 배열 내의 "point"는 숫자가 큰 순서대로 출력해주세요.
+				- "summary"는 사용자의 성격이 반영되는 단어가 들어가도록 간단하게 요약해주세요. ex) “사람들과의 에너지 흐름을 잘 이끌어내는 ~한 사람”
+				- "perfumeRecommend" 배열 내의 "description"은 '이 향수는' 으로 시작되도록 하고 "name"과 "brand"는 실제 존재하는 향수와 브랜드이름으로하고 영어로 응답해줘.
+				- "keywords" 배열에는 4개 항목을 포함하세요.
+				- "perfumeStyle" 내 "notes" 배열에는 5개 항목을 포함하세요.
+				- "scentPoint" 배열에는 5개 항목을 포함하세요.
+				- "perfumeRecommend" 배열에는 3개 항목을 포함하세요.
+				{
+				  "recommendation": "...",
+				  "keywords": [
+				    {
+				      "keyword": "...",
+				      "keywordDescription": "..."
+				    }
+				    // 4개 항목
+				  ],
+				  "perfumeStyle": {
+				    "description": "...",
+				    "notes": [
+				      {
+				        "category": "...",
+				        "categoryDescription": "..."
+				      }
+				      // 5개 항목
+				    ]
+				  },
+				  "scentPoint": [
+				    {
+				      "category": "...",
+				      "point": 1~6 범위의 정수 중 하나
+				    }
+				    // 5개 항목
+				  ],
+				  "summary": "...",
+				  "perfumeRecommend": [
+				    {
+				      "name": "...",
+				      "brand": "...",
+				      "description": "..."
+				    }
+				    // 3개 항목
+				  ]
+				}
+				""", request.getQOne(), request.getQTwo(), request.getQThree(), request.getQFour(),
+			request.getQFive(), request.getQSix(), request.getQSeven(), request.getQEight(), keywordString);
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiScoringUtil.java
+++ b/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiScoringUtil.java
@@ -1,0 +1,74 @@
+package PerfumeOnMe.spring.service.pbti;
+
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiRequestDTO;
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiResponseDTO;
+
+public class PbtiScoringUtil {
+
+	public static PbtiResponseDTO.PbtiResult calculateMbtiType(PbtiRequestDTO.PbtiQuestionRequest request) {
+		int eScore = 0, iScore = 0;
+		int sScore = 0, nScore = 0;
+		int tScore = 0, fScore = 0;
+		int jScore = 0, pScore = 0;
+
+		// Q1~Q2 → E/I
+		if (request.getQOne().contains("칫솔을") || request.getQOne().contains("바로"))
+			eScore++;
+		else if (request.getQOne().contains("수건으로") || request.getQOne().contains("닦고"))
+			iScore++;
+
+		if (request.getQTwo().contains("버튼") || request.getQTwo().contains("분사해"))
+			eScore++;
+		else if (request.getQTwo().contains("중간에") || request.getQTwo().contains("내리는"))
+			iScore++;
+
+		// Q3~Q4 → S/N
+		if (request.getQThree().contains("알림처럼") || request.getQThree().contains("미리"))
+			sScore++;
+		else if (request.getQThree().contains("버스가") || request.getQThree().contains("가방에서 꺼내"))
+			nScore++;
+
+		if (request.getQFour().contains("신호가 바뀌기 직전") || request.getQFour().contains("분사해"))
+			sScore++;
+		else if (request.getQFour().contains("기다리다") || request.getQFour().contains("향이 옅어지면"))
+			nScore++;
+
+		// Q5~Q6 → T/F
+		if (request.getQFive().contains("공간") || request.getQFive().contains("퍼뜨린다"))
+			tScore++;
+		else if (request.getQFive().contains("기분") || request.getQFive().contains("헹굴 때마다"))
+			fScore++;
+
+		if (request.getQSix().contains("목줄") || request.getQSix().contains("가볍게"))
+			tScore++;
+		else if (request.getQSix().contains("손목에") || request.getQSix().contains("레이어링한다"))
+			fScore++;
+
+		// Q7~Q8 → J/P
+		if (request.getQSeven().contains("리모컨을") || request.getQSeven().contains("채널을 돌리며"))
+			jScore++;
+		else if (request.getQSeven().contains("광고가") || request.getQSeven().contains("확실히"))
+			pScore++;
+
+		if (request.getQEight().contains("이불 위에서") || request.getQEight().contains("잔향을"))
+			jScore++;
+		else if (request.getQEight().contains("중앙에서") || request.getQEight().contains("톡톡"))
+			pScore++;
+
+		// 키워드 결정
+		String keyword1 = (eScore > iScore) ? "긍정적 임팩트를 가진 당신"
+			: (eScore < iScore) ? "은은한 집중형인 당신"
+			: "외향과 내향의 균형을 지닌 당신";
+		String keyword2 = (sScore > nScore) ? "촉각에 민감한 당신"
+			: (sScore < nScore) ? "직관으로 이끄는 당신"
+			: "감각과 직관을 오가는 당신";
+		String keyword3 = (tScore > fScore) ? "세부까지 놓치지 않는 당신"
+			: (tScore < fScore) ? "감성을 우선하는 당신"
+			: "사고와 감정을 조화시키는 당신";
+		String keyword4 = (jScore > pScore) ? "미리 움직이는 당신"
+			: (jScore < pScore) ? "순간을 즐기는 당신"
+			: "계획과 즉흥이 공존하는 당신";
+
+		return new PbtiResponseDTO.PbtiResult(keyword1, keyword2, keyword3, keyword4);
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiService.java
@@ -1,0 +1,10 @@
+package PerfumeOnMe.spring.service.pbti;
+
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiRequestDTO;
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiResponseDTO;
+
+public interface PbtiService {
+
+	// PBTI 결과 조회 API
+	PbtiResponseDTO.PbtiQuestionResponse searchPbti(Long userId, PbtiRequestDTO.PbtiQuestionRequest request);
+}

--- a/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiServiceImpl.java
@@ -1,0 +1,46 @@
+package PerfumeOnMe.spring.service.pbti;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
+import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
+import PerfumeOnMe.spring.service.openAi.OpenAiService;
+import PerfumeOnMe.spring.service.openAi.PromptBuilder;
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiRequestDTO;
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PbtiServiceImpl implements PbtiService {
+
+	private final OpenAiService openAiService;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public PbtiResponseDTO.PbtiQuestionResponse searchPbti(Long userId, PbtiRequestDTO.PbtiQuestionRequest request) {
+
+		PbtiResponseDTO.PbtiResult result = PbtiScoringUtil.calculateMbtiType(request);
+
+		String prompt = PromptBuilder.buildPromptFromRequest(request, result);
+
+		// GPT로부터 응답 받기
+		String gptResponse = openAiService.getStructuredResponse(prompt);
+
+		// JSON → DTO 역직렬화
+		try {
+			return objectMapper.readValue(gptResponse, PbtiResponseDTO.PbtiQuestionResponse.class);
+		} catch (JsonProcessingException e) {
+			log.error("GPT 응답 JSON 파싱 실패. 응답: {}", gptResponse, e);
+			throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+		}
+	}
+
+}

--- a/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiServiceImpl.java
@@ -39,7 +39,7 @@ public class PbtiServiceImpl implements PbtiService {
 			return objectMapper.readValue(gptResponse, PbtiResponseDTO.PbtiQuestionResponse.class);
 		} catch (JsonProcessingException e) {
 			log.error("GPT 응답 JSON 파싱 실패. 응답: {}", gptResponse, e);
-			throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+			throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
 		}
 	}
 

--- a/src/main/java/PerfumeOnMe/spring/web/controller/DiaryController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/DiaryController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import PerfumeOnMe.spring.apiPayload.ApiResponse;
 import PerfumeOnMe.spring.apiPayload.code.status.SuccessStatus;
 import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
-import PerfumeOnMe.spring.service.Diary.DiaryService;
+import PerfumeOnMe.spring.service.diary.DiaryService;
 import PerfumeOnMe.spring.web.dto.diary.DiaryRequestDTO;
 import PerfumeOnMe.spring.web.dto.diary.DiaryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/PerfumeOnMe/spring/web/controller/PbtiController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/PbtiController.java
@@ -1,0 +1,45 @@
+package PerfumeOnMe.spring.web.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import PerfumeOnMe.spring.apiPayload.ApiResponse;
+import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
+import PerfumeOnMe.spring.service.pbti.PbtiService;
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiRequestDTO;
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pbti")
+@Tag(name = "PBTI", description = "PBTI CRUD API")
+public class PbtiController {
+
+	private final PbtiService pbtiService;
+
+	// PBTI 결과 조회 API
+	@PostMapping("/result")
+	@Operation(
+		summary = "PBTI 결과 조회",
+		description = "8개의 질문 선택지를 기반으로 PBTI 분석 결과를 조회합니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "PBTI 결과가 조회되었습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PbtiResponseDTO.PbtiQuestionResponse.class)))
+		}
+	)
+	public ResponseEntity<ApiResponse<PbtiResponseDTO.PbtiQuestionResponse>> searchPbti(
+		@RequestBody PbtiRequestDTO.PbtiQuestionRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		PbtiResponseDTO.PbtiQuestionResponse result = pbtiService.searchPbti(userDetails.getUserId(), request);
+		return ResponseEntity.ok(ApiResponse.onSuccess(result));
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/ChatGptRequest.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/ChatGptRequest.java
@@ -1,0 +1,23 @@
+package PerfumeOnMe.spring.web.dto.Pbti;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class ChatGptRequest {
+	private String model;
+	private List<Message> messages;
+	private double temperature;
+
+	@Data
+	@AllArgsConstructor
+	public static class Message {
+		private String role;    // "user" or "system"
+		private String content;
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/ChatGptResponse.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/ChatGptResponse.java
@@ -1,0 +1,23 @@
+package PerfumeOnMe.spring.web.dto.Pbti;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class ChatGptResponse {
+
+	private List<Choice> choices;
+
+	@Data
+	public static class Choice {
+		private int index;
+		private Message message;
+	}
+
+	@Data
+	public static class Message {
+		private String role;
+		private String content;
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiRequestDTO.java
@@ -1,0 +1,44 @@
+package PerfumeOnMe.spring.web.dto.Pbti;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+public class PbtiRequestDTO {
+
+	// PBTI 결과 조회 요청 DTO
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@ToString
+	public static class PbtiQuestionRequest {
+		@JsonProperty("qOne")
+		private String qOne;
+
+		@JsonProperty("qTwo")
+		private String qTwo;
+
+		@JsonProperty("qThree")
+		private String qThree;
+
+		@JsonProperty("qFour")
+		private String qFour;
+
+		@JsonProperty("qFive")
+		private String qFive;
+
+		@JsonProperty("qSix")
+		private String qSix;
+
+		@JsonProperty("qSeven")
+		private String qSeven;
+
+		@JsonProperty("qEight")
+		private String qEight;
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiResponseDTO.java
@@ -75,9 +75,9 @@ public class PbtiResponseDTO {
 	@AllArgsConstructor
 	@NoArgsConstructor
 	public static class PbtiResult {
-		private String keyword1; // J/P 기준
-		private String keyword2; // S/N 기준
-		private String keyword3; // T/F 기준
-		private String keyword4; // E/I 기준
+		private String keyword1;
+		private String keyword2;
+		private String keyword3;
+		private String keyword4;
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiResponseDTO.java
@@ -1,0 +1,83 @@
+package PerfumeOnMe.spring.web.dto.Pbti;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class PbtiResponseDTO {
+
+	// PBTI 결과 조회 응답 DTO
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class PbtiQuestionResponse {
+		private String recommendation;
+		private List<Keyword> keywords;
+		private PerfumeStyle perfumeStyle;
+		private List<ScentPoint> scentPoint;
+		private String summary;
+		private List<PerfumeRecommend> perfumeRecommend;
+
+		@Getter
+		@Builder
+		@AllArgsConstructor
+		@NoArgsConstructor
+		public static class Keyword {
+			private String keyword;
+			private String keywordDescription;
+		}
+
+		@Getter
+		@Builder
+		@AllArgsConstructor
+		@NoArgsConstructor
+		public static class PerfumeStyle {
+			private String description;
+			private List<Note> notes;
+
+			@Getter
+			@Builder
+			@AllArgsConstructor
+			@NoArgsConstructor
+			public static class Note {
+				private String category;
+				private String categoryDescription;
+			}
+		}
+
+		@Getter
+		@Builder
+		@AllArgsConstructor
+		@NoArgsConstructor
+		public static class ScentPoint {
+			private String category;
+			private int point;
+		}
+
+		@Getter
+		@Builder
+		@AllArgsConstructor
+		@NoArgsConstructor
+		public static class PerfumeRecommend {
+			private String name;
+			private String brand;
+			private String description;
+		}
+	}
+
+	// Pbti 키워드 결과 DTO
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class PbtiResult {
+		private String keyword1; // J/P 기준
+		private String keyword2; // S/N 기준
+		private String keyword3; // T/F 기준
+		private String keyword4; // E/I 기준
+	}
+}


### PR DESCRIPTION
## 💡 관련 이슈

#73

## 📢 작업 내용

- **PBTI 분석 결과 조회 API 구현**
  - 8개의 질문에 대한 사용자의 응답에 따른 PBTI 분석 결과를 제공하는 API 구현
- **PbtiScoringUtil 작성**
  - 고정된 8개 문항(Q1~Q8)을 기반으로 MBTI 4자리 결과를 계산하는 로직 구현
  - 각 문항의 응답을 점수화하여 E–I, S–N, T–F, J–P 축으로 성향 결정
- **OpenAiApiClient 작성**
  - WebClient 기반으로 OpenAI API와 통신하는 HTTP 클라이언트 구현
- **OpenAiServiceImpl 작성**
  - 클라이언트(OpenAiApiClient)를 통해 GPT 응답을 받아 JSON 구조로 응답 문자열 반환
- **PbtiServiceImpl 작성**
  - 컨트롤러에서 전달된 질문 응답(PbtiQuestionRequest)을 기반으로 성향 점수 계산

## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
