### PR TITLE
[Feature] #82 - PBTI 결과 저장 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -89,7 +89,9 @@ public enum ErrorStatus implements BaseErrorCode {
 	// PBTI 에러
 	CALL_WEBCLIENT_ERROR(HttpStatus.BAD_REQUEST, "PBTI4001", "WebClient 호출 과정에서 에러가 발생했습니다."),
 	JSON_PARSING_ERROR(HttpStatus.BAD_REQUEST, "PBTI4002", "GPT 응답 Json 파싱 과정에서 에러가 발생했습니다."),
-  
+	SAVE_REDIS_ERROR(HttpStatus.BAD_REQUEST, "PBTI4003", "Redis 저장 중 직렬화 오류가 발생했습니다."),
+	PBTI_REDIS_KEY_EXPIRED(HttpStatus.BAD_REQUEST, "PBTI4004", "사용자의 PBTI 분석 결과가 Redis에서 만료되었거나 저장되어 있지 않습니다."),
+
 	// S3 에러
 	INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "S3IMAGE4001", "지원하지 않은 파일 확장자입니다."),
 

--- a/src/main/java/PerfumeOnMe/spring/converter/PbtiConverter.java
+++ b/src/main/java/PerfumeOnMe/spring/converter/PbtiConverter.java
@@ -1,0 +1,18 @@
+package PerfumeOnMe.spring.converter;
+
+import java.time.LocalDateTime;
+
+import PerfumeOnMe.spring.domain.PBTI;
+import PerfumeOnMe.spring.web.dto.Pbti.PbtiResponseDTO;
+
+public class PbtiConverter {
+
+	// PBTI 결과 저장 API
+	public static PbtiResponseDTO.PbtiSaveResponse toPbtiSaveResponse(PBTI pbti) {
+		return PbtiResponseDTO.PbtiSaveResponse.builder()
+			.id(pbti.getId())
+			.savedName(pbti.getSavedName())
+			.createdAt(LocalDateTime.from(pbti.getCreatedAt()))
+			.build();
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/repository/pbti/PbtiRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/pbti/PbtiRepository.java
@@ -1,9 +1,12 @@
 package PerfumeOnMe.spring.repository.pbti;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import PerfumeOnMe.spring.domain.PBTI;
 
-public interface PbtiRepository extends JpaRepository<PBTI, Long> {
+public interface PbtiRepository extends JpaRepository<PBTI, Long>, PbtiRepositoryCustom {
 
+	Optional<PBTI> findById(Long id);
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/pbti/PbtiRepositoryCustom.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/pbti/PbtiRepositoryCustom.java
@@ -1,0 +1,4 @@
+package PerfumeOnMe.spring.repository.pbti;
+
+public interface PbtiRepositoryCustom {
+}

--- a/src/main/java/PerfumeOnMe/spring/repository/pbti/PbtiRepositoryImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/pbti/PbtiRepositoryImpl.java
@@ -1,0 +1,10 @@
+package PerfumeOnMe.spring.repository.pbti;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PbtiRepositoryImpl implements PbtiRepositoryCustom {
+}

--- a/src/main/java/PerfumeOnMe/spring/service/openAi/PromptBuilder.java
+++ b/src/main/java/PerfumeOnMe/spring/service/openAi/PromptBuilder.java
@@ -35,6 +35,7 @@ public class PromptBuilder {
 				추가로 각 질문에 대한 사용자의 답변을 아래 JSON 포맷에 맞게 분석하여 출력하세요. JSON 이외의 설명은 절대 하지 말고, JSON 데이터만 정확하게 출력해주세요.:
 				
 				- "recommendation"은 '당신은' 으로 시작되도록 하세요.
+				- "perfumeStyle" 내 "notes" 배열의 "category"를 "scentPoint" 내의 "category"에서 사용해주세요.
 				- "scentPoint" 배열 내의 "category"와 "perfumeStyle" 내 "notes" 배열 내의 "category"는 한국어로 응답해주세요.
 				- "scentPoint" 배열 내의 "point"는 숫자가 큰 순서대로 출력해주세요.
 				- "summary"는 사용자의 성격이 반영되는 단어가 들어가도록 간단하게 요약해주세요. ex) “사람들과의 에너지 흐름을 잘 이끌어내는 ~한 사람”

--- a/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiService.java
@@ -7,4 +7,7 @@ public interface PbtiService {
 
 	// PBTI 결과 조회 API
 	PbtiResponseDTO.PbtiQuestionResponse searchPbti(Long userId, PbtiRequestDTO.PbtiQuestionRequest request);
+
+	// PBTI 결과 저장 API
+	PbtiResponseDTO.PbtiSaveResponse savePbti(Long userId, PbtiRequestDTO.PbtiSaveRequest request);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiServiceImpl.java
@@ -1,5 +1,8 @@
 package PerfumeOnMe.spring.service.pbti;
 
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,8 +11,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
 import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
+import PerfumeOnMe.spring.converter.PbtiConverter;
+import PerfumeOnMe.spring.domain.PBTI;
+import PerfumeOnMe.spring.domain.User;
+import PerfumeOnMe.spring.repository.pbti.PbtiRepository;
+import PerfumeOnMe.spring.repository.user.UserRepository;
 import PerfumeOnMe.spring.service.openAi.OpenAiService;
 import PerfumeOnMe.spring.service.openAi.PromptBuilder;
+import PerfumeOnMe.spring.util.JsonUtils;
 import PerfumeOnMe.spring.web.dto.Pbti.PbtiRequestDTO;
 import PerfumeOnMe.spring.web.dto.Pbti.PbtiResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +32,11 @@ public class PbtiServiceImpl implements PbtiService {
 
 	private final OpenAiService openAiService;
 	private final ObjectMapper objectMapper;
+	private final PbtiRepository pbtiRepository;
+	private final UserRepository userRepository;
+	private final StringRedisTemplate stringRedisTemplate;
 
+	// PBTI 결과 조회 API
 	@Override
 	public PbtiResponseDTO.PbtiQuestionResponse searchPbti(Long userId, PbtiRequestDTO.PbtiQuestionRequest request) {
 
@@ -35,12 +48,90 @@ public class PbtiServiceImpl implements PbtiService {
 		String gptResponse = openAiService.getStructuredResponse(prompt);
 
 		// JSON → DTO 역직렬화
+		PbtiResponseDTO.PbtiQuestionResponse response;
 		try {
-			return objectMapper.readValue(gptResponse, PbtiResponseDTO.PbtiQuestionResponse.class);
+			response = objectMapper.readValue(gptResponse, PbtiResponseDTO.PbtiQuestionResponse.class);
 		} catch (JsonProcessingException e) {
 			log.error("GPT 응답 JSON 파싱 실패. 응답: {}", gptResponse, e);
 			throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
 		}
+
+		// Redis에 저장할 DTO 생성
+		PbtiResponseDTO.PbtiRedisDTO redisDTO = PbtiResponseDTO.PbtiRedisDTO.builder()
+			.qOne(request.getQOne())
+			.qTwo(request.getQTwo())
+			.qThree(request.getQThree())
+			.qFour(request.getQFour())
+			.qFive(request.getQFive())
+			.qSix(request.getQSix())
+			.qSeven(request.getQSeven())
+			.qEight(request.getQEight())
+			.recommendation(response.getRecommendation())
+			.summary(response.getSummary())
+			.keywords(response.getKeywords())
+			.perfumeStyle(response.getPerfumeStyle())
+			.scentPoint(response.getScentPoint())
+			.perfumeRecommend(response.getPerfumeRecommend())
+			.build();
+
+		// Redis에 저장
+		try {
+			String redisKey = "pbti:result:" + userId;
+			String json = objectMapper.writeValueAsString(redisDTO);
+			stringRedisTemplate.opsForValue().set(redisKey, json, Duration.ofMinutes(15));
+		} catch (JsonProcessingException e) {
+			throw new GeneralException(ErrorStatus.SAVE_REDIS_ERROR);
+		}
+
+		return response;
+	}
+
+	// PBTI 결과 저장 API
+	@Override
+	public PbtiResponseDTO.PbtiSaveResponse savePbti(Long userId, PbtiRequestDTO.PbtiSaveRequest request) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+
+		// Redis에서 결과 JSON 조회
+		String redisKey = "pbti:result:" + userId;
+		String resultJson = stringRedisTemplate.opsForValue().get(redisKey);
+		if (resultJson == null) {
+			throw new GeneralException(ErrorStatus.PBTI_REDIS_KEY_EXPIRED);
+		}
+
+		// JSON → DTO 역직렬화
+		PbtiResponseDTO.PbtiRedisDTO redisResult;
+		try {
+			redisResult = objectMapper.readValue(resultJson, PbtiResponseDTO.PbtiRedisDTO.class);
+		} catch (JsonProcessingException e) {
+			throw new GeneralException(ErrorStatus.JSON_PARSE_ERROR);
+		}
+
+		PBTI pbti = PBTI.builder()
+			.user(user)
+			.savedName(request.getSavedName())
+			.qOne(redisResult.getQOne())
+			.qTwo(redisResult.getQTwo())
+			.qThree(redisResult.getQThree())
+			.qFour(redisResult.getQFour())
+			.qFive(redisResult.getQFive())
+			.qSix(redisResult.getQSix())
+			.qSeven(redisResult.getQSeven())
+			.qEight(redisResult.getQEight())
+			.recommendation(redisResult.getRecommendation())
+			.summary(redisResult.getSummary())
+			.keywords(JsonUtils.toJson(redisResult.getKeywords()))
+			.perfumeStyle(JsonUtils.toJson(redisResult.getPerfumeStyle()))
+			.scentPoint(JsonUtils.toJson(redisResult.getScentPoint()))
+			.perfumeRecommend(JsonUtils.toJson(redisResult.getPerfumeRecommend()))
+			.build();
+
+		PBTI saved = pbtiRepository.save(pbti);
+
+		// Redis 삭제
+		stringRedisTemplate.delete(redisKey);
+
+		return PbtiConverter.toPbtiSaveResponse(saved);
 	}
 
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/PbtiController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/PbtiController.java
@@ -32,7 +32,8 @@ public class PbtiController {
 		summary = "PBTI 결과 조회",
 		description = "8개의 질문 선택지를 기반으로 PBTI 분석 결과를 조회합니다.",
 		responses = {
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "PBTI 결과가 조회되었습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PbtiResponseDTO.PbtiQuestionResponse.class)))
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "PBTI 결과가 조회되었습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PbtiResponseDTO.PbtiQuestionResponse.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PBTI4002", description = "GPT 응답 Json 파싱 과정에서 에러가 발생했습니다.")
 		}
 	)
 	public ResponseEntity<ApiResponse<PbtiResponseDTO.PbtiQuestionResponse>> searchPbti(
@@ -40,6 +41,24 @@ public class PbtiController {
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 
 		PbtiResponseDTO.PbtiQuestionResponse result = pbtiService.searchPbti(userDetails.getUserId(), request);
+		return ResponseEntity.ok(ApiResponse.onSuccess(result));
+	}
+
+	// PBTI 결과 저장 API
+	@PostMapping("/save")
+	@Operation(
+		summary = "PBTI 결과 저장",
+		description = "PBTI 분석 결과를 DB에 저장합니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "PBTI 결과가 저장되었습니다.", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PbtiResponseDTO.PbtiSaveResponse.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PBTI4004", description = "사용자의 PBTI 분석 결과가 Redis에서 만료되었거나 저장되어 있지 않습니다.")
+		}
+	)
+	public ResponseEntity<ApiResponse<PbtiResponseDTO.PbtiSaveResponse>> savePbti(
+		@RequestBody PbtiRequestDTO.PbtiSaveRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+		PbtiResponseDTO.PbtiSaveResponse result = pbtiService.savePbti(userDetails.getUserId(), request);
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiRequestDTO.java
@@ -41,4 +41,11 @@ public class PbtiRequestDTO {
 		@JsonProperty("qEight")
 		private String qEight;
 	}
+
+	// PBTI 결과 저장 요청 DTO
+	@Getter
+	@Setter
+	public static class PbtiSaveRequest {
+		private String savedName;
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiResponseDTO.java
@@ -1,6 +1,9 @@
 package PerfumeOnMe.spring.web.dto.Pbti;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -79,5 +82,55 @@ public class PbtiResponseDTO {
 		private String keyword2;
 		private String keyword3;
 		private String keyword4;
+	}
+
+	// Pbti 결과 저장 응답 DTO
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class PbtiSaveResponse {
+		private Long id;
+		private String savedName;
+		private LocalDateTime createdAt;
+	}
+
+	// Redis 저장용 DTO
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class PbtiRedisDTO {
+		@JsonProperty("qOne")
+		private String qOne;
+
+		@JsonProperty("qTwo")
+		private String qTwo;
+
+		@JsonProperty("qThree")
+		private String qThree;
+
+		@JsonProperty("qFour")
+		private String qFour;
+
+		@JsonProperty("qFive")
+		private String qFive;
+
+		@JsonProperty("qSix")
+		private String qSix;
+
+		@JsonProperty("qSeven")
+		private String qSeven;
+
+		@JsonProperty("qEight")
+		private String qEight;
+
+		private String recommendation;
+		private String summary;
+
+		private List<PbtiQuestionResponse.Keyword> keywords;
+		private PbtiQuestionResponse.PerfumeStyle perfumeStyle;
+		private List<PbtiQuestionResponse.ScentPoint> scentPoint;
+		private List<PbtiQuestionResponse.PerfumeRecommend> perfumeRecommend;
 	}
 }


### PR DESCRIPTION
## 💡 관련 이슈

#82

## 📢 작업 내용

- **PBTI 분석 결과 저장 API 구현**
  - 기존에 조회한 PBTI 분석 결과를 DB에 저장하는 API 구현
  - 프론트에서는 savedName만 요청하고 서버에서 Redis 값을 꺼내 DB에 저장
- **Redis 연동 로직 추가**
  - PBTI 결과 조회 시 Redis(`pbti:result:{userId}`)키로 결과 캐싱
  - 저장 시 Redis에서 조회하여 결과 활용
- **Redis 전용 응답 DTO 추가**
  - Redis에 저장 및 조회하기 위한 전용 DTO(`PbtiRedisDTO`) 추가
- **PBTI 분석 결과 조회 API 일부 수정**
  - 분석 결과 조회 내용을 Redis에 임시 저장하는 로직 추가

## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
