### PR TITLE
[Refactor] #91 - 로그인 처리를 필터에서 컨트롤러로 변경

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/config/security/SecurityConfig.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/SecurityConfig.java
@@ -51,8 +51,8 @@ public class SecurityConfig {
 			.exceptionHandling(exception -> exception
 				.authenticationEntryPoint(JwtAuthenticationEntryPoint)
 				.accessDeniedHandler(JwtAccessDeniedHandler))
-			// filter 추가 및 수정
-			.addFilterAt(jwtLoginFilter, UsernamePasswordAuthenticationFilter.class)
+			// filter 추가
+			// .addFilterAt(jwtLoginFilter, UsernamePasswordAuthenticationFilter.class) // 로그인 필터 제거
 			.addFilterBefore(JwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(JwtExceptionHandlerFilter, JwtAuthenticationFilter.class)
 			// Session 관련 설정 - 소셜 로그인 과정에서 필요할까봐 IF_REQUIRED로 설정
@@ -72,7 +72,7 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration config = new CorsConfiguration();
-		config.setAllowedOrigins(List.of("*")); // spring: [localhost:8080, localhost:5000], localhost:8081
+		config.setAllowedOrigins(List.of("*")); // spring: [localhost:8080, localhost:5000], localhost:3000
 		config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
 		config.setAllowedHeaders(List.of("Authorization", "Refresh-Token", "Content-Type"));
 		config.setAllowCredentials(false); // origin 바꾸면 true로 설정

--- a/src/main/java/PerfumeOnMe/spring/config/security/auth/controller/LoginController.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/auth/controller/LoginController.java
@@ -1,0 +1,44 @@
+package PerfumeOnMe.spring.config.security.auth.controller;
+
+import java.io.IOException;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import PerfumeOnMe.spring.apiPayload.ApiResponse;
+import PerfumeOnMe.spring.config.security.auth.dto.AuthRequestDTO;
+import PerfumeOnMe.spring.config.security.auth.dto.AuthResponseDTO;
+import PerfumeOnMe.spring.config.security.auth.service.LoginService;
+import PerfumeOnMe.spring.web.dto.user.UserResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class LoginController {
+
+	private final LoginService loginService;
+
+	@PostMapping("/login")
+	@Operation(
+		summary = "로그인 API",
+		description = "사용자의 아이디와 비밀번호로 로그인을 진행하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다.",
+				content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponseDTO.SignupResult.class))),
+		}
+	)
+	public ResponseEntity<ApiResponse<AuthResponseDTO.LoginResult>> login(
+		@RequestBody @Valid AuthRequestDTO.Login loginRequest, HttpServletResponse response) throws IOException {
+		AuthResponseDTO.LoginResult loginResult = loginService.login(loginRequest, response);
+		return ResponseEntity.ok().body(ApiResponse.onSuccess(loginResult));
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/config/security/auth/dto/AuthRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/auth/dto/AuthRequestDTO.java
@@ -1,5 +1,6 @@
 package PerfumeOnMe.spring.config.security.auth.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,7 +9,9 @@ public class AuthRequestDTO {
 	@Getter
 	@NoArgsConstructor
 	public static class Login {
+		@NotNull
 		private String loginId;
+		@NotNull
 		private String password;
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/config/security/auth/filter/JwtLoginFilter.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/auth/filter/JwtLoginFilter.java
@@ -53,7 +53,7 @@ public class JwtLoginFilter extends UsernamePasswordAuthenticationFilter {
 	@Autowired
 	public void setAuthenticationManager(AuthenticationManager authenticationManager) {
 		super.setAuthenticationManager(authenticationManager);
-		setFilterProcessesUrl("/auth/login");
+		setFilterProcessesUrl("/auth/login/filter"); // 접근하지 못하게 경로 수정
 	}
 
 	// 인증 시도

--- a/src/main/java/PerfumeOnMe/spring/config/security/auth/service/LoginService.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/auth/service/LoginService.java
@@ -1,0 +1,13 @@
+package PerfumeOnMe.spring.config.security.auth.service;
+
+import java.io.IOException;
+
+import PerfumeOnMe.spring.config.security.auth.dto.AuthRequestDTO;
+import PerfumeOnMe.spring.config.security.auth.dto.AuthResponseDTO;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface LoginService {
+
+	public AuthResponseDTO.LoginResult login(AuthRequestDTO.Login request, HttpServletResponse response) throws
+		IOException;
+}

--- a/src/main/java/PerfumeOnMe/spring/config/security/auth/service/LoginServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/auth/service/LoginServiceImpl.java
@@ -1,0 +1,89 @@
+package PerfumeOnMe.spring.config.security.auth.service;
+
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
+import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
+import PerfumeOnMe.spring.config.security.auth.converter.AuthConverter;
+import PerfumeOnMe.spring.config.security.auth.dto.AuthRequestDTO;
+import PerfumeOnMe.spring.config.security.auth.dto.AuthResponseDTO;
+import PerfumeOnMe.spring.config.security.auth.manager.LogoutAccessTokenManager;
+import PerfumeOnMe.spring.config.security.auth.manager.RefreshTokenManager;
+import PerfumeOnMe.spring.config.security.auth.provider.CustomLoginAuthenticationProvider;
+import PerfumeOnMe.spring.config.security.auth.provider.JwtTokenProvider;
+import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
+import PerfumeOnMe.spring.domain.enums.Social;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class LoginServiceImpl implements LoginService {
+
+	private final CustomLoginAuthenticationProvider customLoginAuthenticationProvider;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenManager refreshTokenManager;
+	private final LogoutAccessTokenManager logoutAccessTokenManager;
+
+	@Override
+	public AuthResponseDTO.LoginResult login(AuthRequestDTO.Login requestDTO, HttpServletResponse response) {
+
+		// 인증 시도 및 Authentication 획득
+		UsernamePasswordAuthenticationToken loginRequest = UsernamePasswordAuthenticationToken
+			.unauthenticated(requestDTO.getLoginId(), requestDTO.getPassword());
+		Authentication authResult;
+		try {
+			authResult = customLoginAuthenticationProvider.authenticate(loginRequest);
+		} catch (BadCredentialsException failed) {
+			throw new GeneralException(ErrorStatus.PASSWORD_NOT_MATCH);
+		} catch (UsernameNotFoundException failed) {
+			throw new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND);
+		} catch (Exception failed) {
+			throw new GeneralException(ErrorStatus.LOGIN_UNKNOWN_ERROR);
+		}
+
+		// Authentication에서 principal String 추출
+		String loginId = authResult.getName();
+
+		// 사용자의 로그아웃 액세스 토큰이 존재하는 경우 삭제
+		if (logoutAccessTokenManager.findLogoutAccessToken(loginId)) {
+			logoutAccessTokenManager.deleteLogoutAccessToken(loginId);
+		}
+
+		// SecurityContextHolder에 인증 설정
+		SecurityContextHolder.getContext().setAuthentication(authResult);
+
+		return generateAuthResponse(loginId, authResult, Social.LOCAL, response);
+	}
+
+	public AuthResponseDTO.LoginResult generateAuthResponse(String loginId,
+		Authentication request, Social social, HttpServletResponse response) {
+
+		// Authentication에서 userId 추출
+		Long userId = ((CustomUserDetails)request.getPrincipal()).getUserId();
+
+		// 토큰 생성 및 DTO에 담기
+		String accessToken = jwtTokenProvider.createAccessToken(request);
+		String refreshToken = jwtTokenProvider.createRefreshToken(request);
+
+		// 새로 발급한 리프레시 토큰을 Redis에 저장 - 덮어씌우기
+		refreshTokenManager.saveRefreshToken(loginId, refreshToken);
+
+		// 응답 헤더 작성
+		response.setCharacterEncoding("UTF-8");
+		response.setContentType("application/json");
+		response.setStatus(HttpServletResponse.SC_OK);
+		response.setHeader("Authorization", "Bearer " + accessToken);
+
+		return AuthConverter.toLoginResult(refreshToken, userId, social);
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/user/UserServiceImpl.java
@@ -14,11 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
 import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
-import PerfumeOnMe.spring.config.security.auth.converter.AuthConverter;
 import PerfumeOnMe.spring.config.security.auth.dto.AuthResponseDTO;
 import PerfumeOnMe.spring.config.security.auth.manager.LogoutAccessTokenManager;
 import PerfumeOnMe.spring.config.security.auth.manager.RefreshTokenManager;
 import PerfumeOnMe.spring.config.security.auth.provider.JwtTokenProvider;
+import PerfumeOnMe.spring.config.security.auth.service.LoginService;
+import PerfumeOnMe.spring.config.security.auth.service.LoginServiceImpl;
 import PerfumeOnMe.spring.config.security.auth.token.JwtAuthenticationToken;
 import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
 import PerfumeOnMe.spring.converter.FragranceConverter;
@@ -56,6 +57,7 @@ public class UserServiceImpl implements UserService {
 	private final UserNoteRepository userNoteRepository;
 	private final NoteRepository noteRepository;
 	private final UserFragranceRepository userFragranceRepository;
+	private final LoginService loginService;
 
 	// 사용자 회원가입
 	@Override
@@ -93,27 +95,14 @@ public class UserServiceImpl implements UserService {
 
 		// 리프레시 토큰에서 Subject 추출
 		String loginId = jwtTokenProvider.getSubject(reqRefreshToken);
+		UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
 
 		// 토큰 생성 및 DTO에 담기
-		UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
 		Social social = ((CustomUserDetails)userDetails).getSocial();
 		JwtAuthenticationToken request = new JwtAuthenticationToken(
 			userDetails, null, userDetails.getAuthorities(), social);
-		String accessToken = jwtTokenProvider.createAccessToken(request);
-		String refreshToken = jwtTokenProvider.createRefreshToken(request);
-		Long userId = ((CustomUserDetails)userDetails).getUserId();
-		AuthResponseDTO.LoginResult loginResultDTO = AuthConverter.toLoginResult(refreshToken, userId, social);
-
-		// 새로 발급한 리프레시 토큰을 Redis에 저장 - 덮어씌우기
-		refreshTokenManager.saveRefreshToken(loginId, refreshToken);
-
-		// 응답 헤더 작성
-		response.setCharacterEncoding("UTF-8");
-		response.setContentType("application/json");
-		response.setStatus(HttpServletResponse.SC_OK);
-		response.setHeader("Authorization", "Bearer " + accessToken);
-
-		return loginResultDTO;
+		return ((LoginServiceImpl)loginService)
+			.generateAuthResponse(loginId, request, social, response);
 	}
 
 	// 사용자 로그아웃 - 액세스 토큰과 리프레시 토큰 블랙리스트화


### PR DESCRIPTION
## 💡 관련 이슈

#91
## 📢 작업 내용

- **로그인 처리를 필터에서 컨트롤러로 변경**
  - Controller, Service 코드 작성
  - 기존 로그인 필터 경로 변경 및 주석 처리
- **로그인과 토큰 재발급 API에 중복되는 코드 메서드로 추출**

## 🗨️ 리뷰 요구사항(선택)

- 이제 로그인도 Swagger에서 API 호출할 수 있습니다!

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
