### PR TITLE
[Fix] #91 - 카카오 소셜 로그인에서 회원가입 로직 수정

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/PerfumeOnMe/spring/apiPayload/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	LOGIN_PARSING_FAIL(HttpStatus.BAD_REQUEST, "MEMBER4004", "로그인 DTO 변환을 실패했습니다."),
 	LOGIN_UNKNOWN_ERROR(HttpStatus.BAD_REQUEST, "MEMBER4005", "로그인 중 알 수 없는 오류가 발생했습니다."),
 	NICKNAME_DUPLICATE(HttpStatus.BAD_REQUEST, "MEMBER4006", "이미 사용된 닉네임입니다."),
+	USER_ID_NULL(HttpStatus.UNAUTHORIZED, "MEMBER4007", "유저 정보가 존재 하지 않습니다. "),
 
 	// 토큰 에러
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 토큰입니다."),
@@ -70,7 +71,7 @@ public enum ErrorStatus implements BaseErrorCode {
 	INVALID_IMAGEKEYWORD_VALUE(HttpStatus.BAD_REQUEST, "IMAGEKEYWORD4001", "잘못된 키워드값입니다. 키워드 값을 확인해주세요."),
 	EXPIRED_IMAGEKEYWORD_RESULT(HttpStatus.REQUEST_TIMEOUT, "IMAGEKEYWORD4002", "생성할 이미지 키워드 결과가 만료되었습니다."),
 	ALREADY_KEYWORD_NAME(HttpStatus.BAD_REQUEST, "IMAGEKEYWORD4003", "동일한 이름으로 저장된 결과가 존재합니다."),
-	INVALID_IMAGEKEYWORD_ID(HttpStatus.BAD_REQUEST, "IMAGEKEYWORD4004", "해당 ID의 이미지 결과가 존재하지 않습니다."),
+	INVALID_IMAGEKEYWORD_ID(HttpStatus.BAD_REQUEST, "IMAGEKEYWORD4004", "해당 ID의 이미지 결과를 조회할 수 없습니다."),
 
 	// FastAPI 연동 에러
 	FASTAPI_COMMUNICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FASTAPI5001", "FastAPI 서버 통신 중 오류가 발생했습니다."),
@@ -96,6 +97,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
 	// S3 에러
 	INVALID_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "S3IMAGE4001", "지원하지 않은 파일 확장자입니다."),
+
+	// 향수공방 에러
+	WORKSHOP_USER_NOT_MATCH(HttpStatus.BAD_REQUEST, "WORKSHOP4004", "해당 향수공방 결과에 접근할 수 없습니다."),
+	WORKSHOP_ID_NULL(HttpStatus.UNAUTHORIZED, "WORKSHOP4005", "해당 향수공방 결과 정보가 존재하지 않습니다."),
 
 	// 예시,,,
 	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");

--- a/src/main/java/PerfumeOnMe/spring/config/security/oauth/service/KakaoService.java
+++ b/src/main/java/PerfumeOnMe/spring/config/security/oauth/service/KakaoService.java
@@ -50,7 +50,7 @@ public class KakaoService implements OAuthService {
 		// 이미 가입한 사용자라면 꺼내고, 아니라면 회원가입 진행
 		User user = userRepository.findUserByLoginId(email).orElseGet(() -> {
 			User newUser = OAuthConverter.toSignupUser(
-				Social.KAKAO, "kakao" + email, name, "password", imageUrl, nickname);
+				Social.KAKAO, email, name, "password", imageUrl, nickname);
 			return userRepository.save(newUser);
 		});
 

--- a/src/main/java/PerfumeOnMe/spring/converter/WorkshopConverter.java
+++ b/src/main/java/PerfumeOnMe/spring/converter/WorkshopConverter.java
@@ -1,0 +1,58 @@
+package PerfumeOnMe.spring.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import PerfumeOnMe.spring.domain.Workshop;
+import PerfumeOnMe.spring.web.dto.workshop.WorkshopResponseDTO;
+
+public class WorkshopConverter {
+
+	/** 향수공방 목록 converter*/
+	public static List<WorkshopResponseDTO.WorkshopListResponseDTO> toWorkshopListResponse(
+		List<Workshop> workshops
+	) {
+		return workshops.stream()
+			.map(workshop -> WorkshopResponseDTO.WorkshopListResponseDTO.builder()
+				.workshopId(workshop.getId())
+				.savedName(workshop.getSavedName())
+				.createdAt(workshop.getCreatedAt())
+				.build())
+			.toList();
+	}
+
+	public static WorkshopResponseDTO.WorkshopDetailResponseDTO toWorkshopDetailResponse(Workshop workshop) {
+		// 추천 향수 리스트 JSON 파싱
+		List<WorkshopResponseDTO.RecommendedFragranceDTO> recommendedFragranceDTOList =
+			parseFragranceJson(workshop.getRecommendedFragranceJson());
+
+		return WorkshopResponseDTO.WorkshopDetailResponseDTO.builder()
+			.keywordSummary(workshop.getKeywordSummary())
+			.firstImpression(workshop.getFirstImpression())
+			.centerImpression(workshop.getCenterImpression())
+			.lastImpression(workshop.getLastImpression())
+			.tendency(workshop.getTendency())
+			.recommendedFragranceJson(recommendedFragranceDTOList)
+			.build();
+	}
+
+	/** JSON 문자열을 추천 향수 DTO 리스트로 변환 */
+	private static List<WorkshopResponseDTO.RecommendedFragranceDTO> parseFragranceJson(String fragranceJson) {
+		if (fragranceJson == null || fragranceJson.trim().isEmpty()) {
+			return new ArrayList<>();
+		}
+
+		try {
+			ObjectMapper objectMapper = new ObjectMapper();
+			return objectMapper.readValue(fragranceJson,
+				new TypeReference<List<WorkshopResponseDTO.RecommendedFragranceDTO>>() {
+				});
+		} catch (JsonProcessingException e) {
+			return new ArrayList<>();
+		}
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/repository/workshop/WorkshopRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/workshop/WorkshopRepository.java
@@ -1,0 +1,16 @@
+package PerfumeOnMe.spring.repository.workshop;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import PerfumeOnMe.spring.domain.User;
+import PerfumeOnMe.spring.domain.Workshop;
+
+public interface WorkshopRepository extends JpaRepository<Workshop, Long> {
+
+	List<Workshop> findAllByUser(User user);
+
+	Optional<Workshop> findByIdAndUser(Long id, User user);
+}

--- a/src/main/java/PerfumeOnMe/spring/service/workshop/WorkshopService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/workshop/WorkshopService.java
@@ -1,0 +1,73 @@
+package PerfumeOnMe.spring.service.workshop;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
+import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
+import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
+import PerfumeOnMe.spring.converter.WorkshopConverter;
+import PerfumeOnMe.spring.domain.User;
+import PerfumeOnMe.spring.domain.Workshop;
+import PerfumeOnMe.spring.repository.user.UserRepository;
+import PerfumeOnMe.spring.repository.workshop.WorkshopRepository;
+import PerfumeOnMe.spring.service.user.UserService;
+import PerfumeOnMe.spring.web.dto.workshop.WorkshopResponseDTO;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class WorkshopService {
+	private final WorkshopRepository workshopRepository;
+	private final UserRepository userRepository;
+	private final UserService userService;
+
+	@Transactional(readOnly = true)
+	public List<WorkshopResponseDTO.WorkshopListResponseDTO> findAllWorkshopsByUser(CustomUserDetails userDetails) {
+
+		Long userId = userDetails.getUserId();
+
+		// 유저 ID 검증
+		if (userId == null) {
+			throw new GeneralException(ErrorStatus.USER_ID_NULL);
+		}
+
+		// 유저 존재 여부 검증
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+
+		// 응답생성
+		List<Workshop> workshops = workshopRepository.findAllByUser(user);
+
+		return WorkshopConverter.toWorkshopListResponse(workshops);
+	}
+
+	@Transactional(readOnly = true)
+	public WorkshopResponseDTO.WorkshopDetailResponseDTO findWorkshopById(
+		Long workshopId, CustomUserDetails userDetails) {
+		Long userId = userDetails.getUserId();
+
+		// 유저 ID NULL 검증
+		if (userId == null) {
+			throw new GeneralException(ErrorStatus.USER_ID_NULL);
+		}
+
+		// 유저 존재 여부 검증
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+
+		// 향수 공방 존재 여부 검증
+		if (!workshopRepository.existsById(workshopId)) {
+			throw new GeneralException(ErrorStatus.WORKSHOP_ID_NULL);
+		}
+		// 사용자의 향수공방 여부 검증
+		Workshop workshop = workshopRepository.findByIdAndUser(workshopId, user)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.WORKSHOP_USER_NOT_MATCH));
+
+		// 응답 생성
+		return WorkshopConverter.toWorkshopDetailResponse(workshop);
+	}
+
+}

--- a/src/main/java/PerfumeOnMe/spring/web/controller/ImageKeywordController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/ImageKeywordController.java
@@ -37,8 +37,7 @@ public class ImageKeywordController {
 	@GetMapping("/result/list")
 	@Operation(
 		summary = "이미지 키워드 목록 조회 (마이페이지)",
-		description = "해당 유저가 저장한 이미지 키워드 결과 목록을 조회합니다.\n\n" +
-			"마이페이지 내 '추천 결과' 영역에 출력되는 카드들의 리스트 데이터입니다.",
+		description = "해당 유저가 저장한 이미지 키워드 결과 목록을 조회합니다.",
 		responses = {
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(
 				responseCode = "COMMON200",

--- a/src/main/java/PerfumeOnMe/spring/web/controller/WorkshopController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/WorkshopController.java
@@ -1,0 +1,95 @@
+package PerfumeOnMe.spring.web.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import PerfumeOnMe.spring.apiPayload.ApiResponse;
+import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
+import PerfumeOnMe.spring.service.workshop.WorkshopService;
+import PerfumeOnMe.spring.web.dto.workshop.WorkshopResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/workshop")
+@Tag(name = "Workshop", description = "향수공방 API")
+public class WorkshopController {
+
+	private final WorkshopService workshopService;
+
+	/** 향수공방 목록 조회*/
+	@GetMapping("/result/list")
+	@Operation(
+		summary = "향수공방 목록 조회 (마이페이지)",
+		description = "해당 유저가 저장한 향수공방 결과 목록을 조회합니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "COMMON200",
+				description = "요청에 성공하였습니다.",
+				content = @Content(
+					mediaType = "application/json",
+					schema = @Schema(implementation = WorkshopResponseDTO.WorkshopListResponseDTO.class)
+				)
+			)
+		}
+	)
+	public ResponseEntity<ApiResponse<List<WorkshopResponseDTO.WorkshopListResponseDTO>>> getWorkshopList(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		return ResponseEntity.ok(ApiResponse.onSuccess(workshopService
+			.findAllWorkshopsByUser(
+				userDetails)));
+	}
+
+	/** 향수공방 결과 상세조회*/
+	@GetMapping("/{workshopId}")
+	@Operation(
+		summary = "향수공방 결과 상세조회",
+		description = "저장된 향수공방 결과의 상세정보를 조회합니다. 키워드 요약, 인상 설명, 성향 분석, 추천 향수 목록을 포함합니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "COMMON200",
+				description = "요청에 성공하였습니다.",
+				content = @Content(
+					mediaType = "application/json",
+					schema = @Schema(implementation = WorkshopResponseDTO.WorkshopDetailResponseDTO.class)
+				)
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "COMMON401",
+				description = "인증이 필요합니다. 액세스 토큰을 입력해주세요."
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "WORKSHOP4004",
+				description = "해당 향수공방 결과에 접근할 수 없습니다."
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+				responseCode = "WORKSHOP4005",
+				description = "해당 향수공방 결과 정보가 존재하지 않습니다."
+			)
+		}
+	)
+	public ResponseEntity<ApiResponse<WorkshopResponseDTO.WorkshopDetailResponseDTO>> getWorkshopDetail(
+		@Parameter(description = "조회할 향수공방 결과 ID", required = true, example = "1")
+		@PathVariable Long workshopId,
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		return ResponseEntity.ok(ApiResponse.onSuccess(workshopService
+			.findWorkshopById(workshopId,
+				userDetails)));
+	}
+
+}

--- a/src/main/java/PerfumeOnMe/spring/web/dto/workshop/WorkshopRequestDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/workshop/WorkshopRequestDTO.java
@@ -1,0 +1,4 @@
+package PerfumeOnMe.spring.web.dto.workshop;
+
+public class WorkshopRequestDTO {
+}

--- a/src/main/java/PerfumeOnMe/spring/web/dto/workshop/WorkshopResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/workshop/WorkshopResponseDTO.java
@@ -1,0 +1,76 @@
+package PerfumeOnMe.spring.web.dto.workshop;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "향수공방 응답 DTO")
+public class WorkshopResponseDTO {
+
+	@Builder
+	@Getter
+	@Schema(description = "마이페이지 향수공방 목록 응답")
+	public static class WorkshopListResponseDTO {
+		private Long workshopId;
+		private String savedName;
+		private LocalDateTime createdAt;
+	}
+
+	@Builder
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Schema(description = "향수공방 결과 상세조회")
+	public static class WorkshopDetailResponseDTO {
+
+		@Schema(description = "키워드 요약", example = "#상큼한첫인상 #감정전달향 #무디한마무리")
+		private String keywordSummary;
+
+		@Schema(description = "첫인상 설명", example = "상큼한 시트러스가 먼저 퍼지며, 활기차고 개방적인 에너지를 전달합니다...")
+		private String firstImpression;
+
+		@Schema(description = "중간 인상 설명", example = "곧이어 재스민의 은은한 꽃향기가 중심을 잡습니다...")
+		private String centerImpression;
+
+		@Schema(description = "마지막 인상 설명", example = "이 향기의 핵심은 단연 우디 노트입니다...")
+		private String lastImpression;
+
+		@Schema(description = "성향 분석", example = "🌞 겉으로는 밝고 유쾌하며 누구든 쉽게 다가갈 수 있는 사람...")
+		private String tendency;
+
+		@Schema(description = "추천 향수 목록")
+		@JsonProperty("recommendedFragranceJson")
+		private List<RecommendedFragranceDTO> recommendedFragranceJson;
+	}
+
+	@Builder
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Schema(description = "추천 향수 정보")
+	public static class RecommendedFragranceDTO {
+
+		@Schema(description = "브랜드명", example = "딥디크")
+		private String brand;
+
+		@Schema(description = "향수명", example = "탐다오")
+		private String name;
+
+		@Schema(description = "향수 설명", example = "백단향의 고요한 잔향이 매력적인 향수")
+		private String description;
+
+		@Schema(description = "향수 가격", example = "30000")
+		private int price;
+
+		@Schema(description = "이미지 URL", example = "www.s3.com")
+		private String imageUrl;
+	}
+
+}


### PR DESCRIPTION
## 💡 관련 이슈

#91

## 📢 작업 내용

- **loginId 저장할 때, "kakao" prefix 삭제**
  - prefix 때문에 이미 가입한 사용자를 인식하지 못하고 회원가입 진행 -> nickname unique 제약 조건 위반으로 DataIntegrityViolationException 발생

## 🗨️ 리뷰 요구사항(선택)

- 바로 머지하겠습니다...

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
