### PR TITLE
[Refactor] #92 - PBTI 결과 조회, 상세 조회 API 수정

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/service/external/FastApiClient.java
+++ b/src/main/java/PerfumeOnMe/spring/service/external/FastApiClient.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import PerfumeOnMe.spring.web.dto.external.FastApiPbtiRecommendResponse;
 import PerfumeOnMe.spring.web.dto.external.FastApiRecommendRequest;
 import PerfumeOnMe.spring.web.dto.external.FastApiRecommendResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,9 @@ public class FastApiClient {
 
 	@Value("${external.fastapi.recommend-url}")
 	private String fastApiRecommendUrl;
+
+	@Value("${external.fastapi.pbti-recommend-url}")
+	private String pbtiRecommendUrl;
 
 	public FastApiRecommendResponse getFullRecommendation(FastApiRecommendRequest request) {
 		try {
@@ -39,4 +43,23 @@ public class FastApiClient {
 			return new FastApiRecommendResponse(); //임시조치 : FAST API 서버 없을 때 기본응답반환으로 서버 유지
 		}
 	}
+
+	public FastApiPbtiRecommendResponse getPbtiRecommendation(FastApiRecommendRequest.PbtiRequest request) {
+		try {
+			HttpHeaders headers = new HttpHeaders();
+			headers.setContentType(MediaType.APPLICATION_JSON);
+
+			HttpEntity<FastApiRecommendRequest.PbtiRequest> entity = new HttpEntity<>(request, headers);
+
+			ResponseEntity<FastApiPbtiRecommendResponse> response =
+				restTemplate.exchange(pbtiRecommendUrl, HttpMethod.POST, entity, FastApiPbtiRecommendResponse.class);
+
+			return response.getBody();
+
+		} catch (Exception e) {
+			// throw new GeneralException(ErrorStatus.FASTAPI_COMMUNICATION_ERROR);
+			return new FastApiPbtiRecommendResponse(); //임시조치 : FAST API 서버 없을 때 기본응답반환으로 서버 유지
+		}
+	}
+
 }

--- a/src/main/java/PerfumeOnMe/spring/service/openAi/PromptBuilder.java
+++ b/src/main/java/PerfumeOnMe/spring/service/openAi/PromptBuilder.java
@@ -39,11 +39,9 @@ public class PromptBuilder {
 				- "scentPoint" 배열 내의 "category"와 "perfumeStyle" 내 "notes" 배열 내의 "category"는 한국어로 응답해주세요.
 				- "scentPoint" 배열 내의 "point"는 숫자가 큰 순서대로 출력해주세요.
 				- "summary"는 사용자의 성격이 반영되는 단어가 들어가도록 간단하게 요약해주세요. ex) “사람들과의 에너지 흐름을 잘 이끌어내는 ~한 사람”
-				- "perfumeRecommend" 배열 내의 "description"은 '이 향수는' 으로 시작되도록 하고 "name"과 "brand"는 실제 존재하는 향수와 브랜드이름으로하고 영어로 응답해줘.
 				- "keywords" 배열에는 4개 항목을 포함하세요.
 				- "perfumeStyle" 내 "notes" 배열에는 5개 항목을 포함하세요.
 				- "scentPoint" 배열에는 5개 항목을 포함하세요.
-				- "perfumeRecommend" 배열에는 3개 항목을 포함하세요.
 				{
 				  "recommendation": "...",
 				  "keywords": [
@@ -70,15 +68,7 @@ public class PromptBuilder {
 				    }
 				    // 5개 항목
 				  ],
-				  "summary": "...",
-				  "perfumeRecommend": [
-				    {
-				      "name": "...",
-				      "brand": "...",
-				      "description": "..."
-				    }
-				    // 3개 항목
-				  ]
+				  "summary": "..."x`
 				}
 				""", request.getQOne(), request.getQTwo(), request.getQThree(), request.getQFour(),
 			request.getQFive(), request.getQSix(), request.getQSeven(), request.getQEight(), keywordString);

--- a/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/pbti/PbtiServiceImpl.java
@@ -18,11 +18,14 @@ import PerfumeOnMe.spring.domain.PBTI;
 import PerfumeOnMe.spring.domain.User;
 import PerfumeOnMe.spring.repository.pbti.PbtiRepository;
 import PerfumeOnMe.spring.repository.user.UserRepository;
+import PerfumeOnMe.spring.service.external.FastApiClient;
 import PerfumeOnMe.spring.service.openAi.OpenAiService;
 import PerfumeOnMe.spring.service.openAi.PromptBuilder;
 import PerfumeOnMe.spring.util.JsonUtils;
 import PerfumeOnMe.spring.web.dto.Pbti.PbtiRequestDTO;
 import PerfumeOnMe.spring.web.dto.Pbti.PbtiResponseDTO;
+import PerfumeOnMe.spring.web.dto.external.FastApiPbtiRecommendResponse;
+import PerfumeOnMe.spring.web.dto.external.FastApiRecommendRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -37,6 +40,7 @@ public class PbtiServiceImpl implements PbtiService {
 	private final PbtiRepository pbtiRepository;
 	private final UserRepository userRepository;
 	private final StringRedisTemplate stringRedisTemplate;
+	private final FastApiClient fastApiClient;
 
 	// PBTI 결과 조회 API
 	@Override
@@ -57,6 +61,34 @@ public class PbtiServiceImpl implements PbtiService {
 			log.error("GPT 응답 JSON 파싱 실패. 응답: {}", gptResponse, e);
 			throw new GeneralException(ErrorStatus.JSON_PARSING_ERROR);
 		}
+
+		// FastAPI 호출로 perfumeRecommend 대체
+		FastApiRecommendRequest.PbtiRequest fastApiRequest = new FastApiRecommendRequest.PbtiRequest(
+			request.getQOne(),
+			request.getQTwo(),
+			request.getQThree(),
+			request.getQFour(),
+			request.getQFive(),
+			request.getQSix(),
+			request.getQSeven(),
+			request.getQEight()
+		);
+
+		FastApiPbtiRecommendResponse fastApiResponse = fastApiClient.getPbtiRecommendation(fastApiRequest);
+
+		// ⬇ FastAPI 향수 추천 결과 매핑
+		List<PbtiResponseDTO.PbtiQuestionResponse.PerfumeRecommend> mappedPerfumes = fastApiResponse.getPerfumeRecommend()
+			.stream()
+			.map(r -> PbtiResponseDTO.PbtiQuestionResponse.PerfumeRecommend.builder()
+				.name(r.getName())
+				.brand(r.getBrand())
+				.description(r.getDescription())
+				.perfumeImageUrl(r.getPerfumeImageUrl())
+				.build())
+			.collect(Collectors.toList());
+
+		// 결과 세팅
+		response.setPerfumeRecommend(mappedPerfumes);
 
 		// Redis에 저장할 DTO 생성
 		PbtiResponseDTO.PbtiRedisDTO redisDTO = PbtiResponseDTO.PbtiRedisDTO.builder()

--- a/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/Pbti/PbtiResponseDTO.java
@@ -9,11 +9,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 public class PbtiResponseDTO {
 
 	// PBTI 결과 조회 응답 DTO
 	@Getter
+	@Setter
 	@Builder
 	@AllArgsConstructor
 	@NoArgsConstructor
@@ -35,6 +37,7 @@ public class PbtiResponseDTO {
 		}
 
 		@Getter
+		@Setter
 		@Builder
 		@AllArgsConstructor
 		@NoArgsConstructor
@@ -69,6 +72,7 @@ public class PbtiResponseDTO {
 			private String name;
 			private String brand;
 			private String description;
+			private String perfumeImageUrl;
 		}
 	}
 
@@ -211,6 +215,7 @@ public class PbtiResponseDTO {
 			private String name;
 			private String brand;
 			private String description;
+			private String perfumeImageUrl;
 		}
 	}
 

--- a/src/main/java/PerfumeOnMe/spring/web/dto/external/FastApiPbtiRecommendResponse.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/external/FastApiPbtiRecommendResponse.java
@@ -1,0 +1,26 @@
+package PerfumeOnMe.spring.web.dto.external;
+
+import java.util.Collections;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FastApiPbtiRecommendResponse {
+	private List<PbtiPerfumeRecommendation> perfumeRecommend = Collections.emptyList(); // 기본값
+
+	public FastApiPbtiRecommendResponse(List<PbtiPerfumeRecommendation> perfumeRecommend) {
+		this.perfumeRecommend = perfumeRecommend;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class PbtiPerfumeRecommendation {
+		private String name;
+		private String brand;
+		private String description;
+		private String perfumeImageUrl;
+	}
+}

--- a/src/main/java/PerfumeOnMe/spring/web/dto/external/FastApiRecommendRequest.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/external/FastApiRecommendRequest.java
@@ -1,5 +1,7 @@
 package PerfumeOnMe.spring.web.dto.external;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,4 +17,28 @@ public class FastApiRecommendRequest {
 	private String gender;
 	private String season;
 	private String personality;
+
+	// PBTI용 요청 DTO
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class PbtiRequest {
+		@JsonProperty("qOne")
+		private String qOne;
+		@JsonProperty("qTwo")
+		private String qTwo;
+		@JsonProperty("qThree")
+		private String qThree;
+		@JsonProperty("qFour")
+		private String qFour;
+		@JsonProperty("qFive")
+		private String qFive;
+		@JsonProperty("qSix")
+		private String qSix;
+		@JsonProperty("qSeven")
+		private String qSeven;
+		@JsonProperty("qEight")
+		private String qEight;
+	}
 }


### PR DESCRIPTION
## 💡 관련 이슈

#92

## 📢 작업 내용

- **PBTI 결과 조회, 상세 조회 API 수정**
  - 기존 GPT 프롬프트를 통해 받아오던 향수 추천 응답을 FastAPI 서버를 구축해 응답을 받아옴
- **FastAPI 서버 구축**
  - 사용자 맞춤 향수 추천 로직을 구현
  - 사용자의 성격, 성향과 향수의 특징을 임베딩해 유사도 기반으로 추천
  - 자체 데이터 시트내의 향수 리스트 중에서 추천
- **FastAPI 전용 요청, 응답 DTO 생성**
  - FastAPI와 통신하는 DTO

## 🗨️ 리뷰 요구사항(선택)

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
