### PR TITLE
[Feature] #123 - 메인페이지 나만의향수 조회 API 구현

### DIFF
--- a/src/main/java/PerfumeOnMe/spring/converter/FragranceConverter.java
+++ b/src/main/java/PerfumeOnMe/spring/converter/FragranceConverter.java
@@ -169,4 +169,13 @@ public class FragranceConverter {
 			.build();
 	}
 
+	// 메인페이지 나만의 향수 결과 변환
+	public static FragranceResponseDTO.FragranceMyPerfumeResult toMyPerfumeResult(
+		boolean exists, List<FragranceResponseDTO.MyPerfume> myPerfumeList) {
+		return FragranceResponseDTO.FragranceMyPerfumeResult.builder()
+			.exists(exists)
+			.myPerfumeList(myPerfumeList)
+			.build();
+	}
+
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/imagekeyword/ImageKeywordRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/imagekeyword/ImageKeywordRepository.java
@@ -15,4 +15,6 @@ public interface ImageKeywordRepository extends JpaRepository<ImageKeyword, Long
 
 	// 동일한 사용자와 저장 이름이 존재하는지 확인
 	boolean existsByUserAndSavedName(User user, String savedName);
+
+	Optional<ImageKeyword> findFirstByUserOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/PerfumeOnMe/spring/repository/workshop/WorkshopRepository.java
+++ b/src/main/java/PerfumeOnMe/spring/repository/workshop/WorkshopRepository.java
@@ -15,4 +15,6 @@ public interface WorkshopRepository extends JpaRepository<Workshop, Long> {
 	Optional<Workshop> findByIdAndUser(Long id, User user);
 
 	boolean existsByUserAndSavedName(User user, String savedName);
+
+	Optional<Workshop> findFirstByUserOrderByCreatedAtDesc(User user);
 }

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceService.java
@@ -27,5 +27,8 @@ public interface FragranceService {
 		Long userId);
 
 	FragranceResponseDTO.FragranceMdChoiceResult getFragranceMdChoice(CustomUserDetails userDetails);
+
+	// 향수 메인페이지 나만의 향수 조회 API
+	FragranceResponseDTO.FragranceMyPerfumeResult getFragranceMyPerfume(CustomUserDetails userDetails);
 }
 

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
@@ -79,8 +79,7 @@ public class FragranceServiceImpl implements FragranceService {
 	@Override
 	@Transactional(readOnly = false)
 	public FragranceResponseDTO.FavoriteResponseDTO addFavorite(Long userId, Long fragranceId) {
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+		User user = findUserById(userId);
 		Fragrance fragrance = fragranceRepository.findById(fragranceId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.FRAGRANCE_NOT_FOUND));
 
@@ -101,8 +100,7 @@ public class FragranceServiceImpl implements FragranceService {
 	@Override
 	@Transactional(readOnly = false)
 	public FragranceResponseDTO.FavoriteCancelResponseDTO deleteFavorite(Long userId, Long fragranceId) {
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+		User user = findUserById(userId);
 		Fragrance fragrance = fragranceRepository.findById(fragranceId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.FRAGRANCE_NOT_FOUND));
 
@@ -192,8 +190,7 @@ public class FragranceServiceImpl implements FragranceService {
 	public FragranceResponseDTO.FragranceMdChoiceResult getFragranceMdChoice(CustomUserDetails userDetails) {
 
 		// 사용자 조회
-		User user = userRepository.findUserByLoginId(userDetails.getUsername())
-			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+		User user = findUserById(userDetails.getUserId());
 
 		// 사용자 선호 향 조회
 		List<Long> noteList = user.getUserNoteList().stream()
@@ -226,8 +223,7 @@ public class FragranceServiceImpl implements FragranceService {
 	@Override
 	public FragranceResponseDTO.FragranceMyPerfumeResult getFragranceMyPerfume(CustomUserDetails userDetails) {
 		// 사용자 조회
-		User user = userRepository.findUserByLoginId(userDetails.getUsername())
-			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+		User user = findUserById(userDetails.getUserId());
 
 		Optional<Workshop> workshop = workshopRepository.findFirstByUserOrderByCreatedAtDesc(user);
 		Optional<ImageKeyword> imageKeyword = imageKeywordRepository.findFirstByUserOrderByCreatedAtDesc(user);
@@ -286,5 +282,13 @@ public class FragranceServiceImpl implements FragranceService {
 			// JSON 파싱 실패 시 빈 리스트 반환
 			return List.of();
 		}
+	}
+
+	/**
+	 * 사용자 ID로 사용자 조회 (공통 메서드)
+	 */
+	private User findUserById(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
+++ b/src/main/java/PerfumeOnMe/spring/service/fragrance/FragranceServiceImpl.java
@@ -1,6 +1,7 @@
 package PerfumeOnMe.spring.service.fragrance;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
@@ -10,22 +11,29 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import PerfumeOnMe.spring.apiPayload.code.status.ErrorStatus;
 import PerfumeOnMe.spring.apiPayload.exception.GeneralException;
 import PerfumeOnMe.spring.config.security.auth.userDetails.CustomUserDetails;
 import PerfumeOnMe.spring.converter.FragranceConverter;
 import PerfumeOnMe.spring.domain.Fragrance;
+import PerfumeOnMe.spring.domain.ImageKeyword;
 import PerfumeOnMe.spring.domain.User;
+import PerfumeOnMe.spring.domain.Workshop;
 import PerfumeOnMe.spring.domain.enums.FragranceGender;
 import PerfumeOnMe.spring.domain.enums.FragranceType;
 import PerfumeOnMe.spring.domain.enums.UserGender;
 import PerfumeOnMe.spring.domain.mapping.UserFragrance;
 import PerfumeOnMe.spring.repository.fragrance.FragranceRepository;
+import PerfumeOnMe.spring.repository.imagekeyword.ImageKeywordRepository;
 import PerfumeOnMe.spring.repository.location.LocationRepository;
 import PerfumeOnMe.spring.repository.note.NoteRepository;
 import PerfumeOnMe.spring.repository.season.SeasonRepository;
 import PerfumeOnMe.spring.repository.user.UserRepository;
 import PerfumeOnMe.spring.repository.userFragrance.UserFragranceRepository;
+import PerfumeOnMe.spring.repository.workshop.WorkshopRepository;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceRequestDTO;
 import PerfumeOnMe.spring.web.dto.fragrance.FragranceResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +49,9 @@ public class FragranceServiceImpl implements FragranceService {
 	private final NoteRepository noteRepository;
 	private final SeasonRepository seasonRepository;
 	private final LocationRepository locationRepository;
+	private final WorkshopRepository workshopRepository;
+	private final ImageKeywordRepository imageKeywordRepository;
+	private final ObjectMapper objectMapper;
 
 	// 향수 상세 API
 	@Override
@@ -209,5 +220,71 @@ public class FragranceServiceImpl implements FragranceService {
 			}).toList();
 
 		return FragranceConverter.toMdChoiceResult(content, name, nickname);
+	}
+
+	// 메인페이지 나만의 향수 조회 API
+	@Override
+	public FragranceResponseDTO.FragranceMyPerfumeResult getFragranceMyPerfume(CustomUserDetails userDetails) {
+		// 사용자 조회
+		User user = userRepository.findUserByLoginId(userDetails.getUsername())
+			.orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_ID_NOT_FOUND));
+
+		Optional<Workshop> workshop = workshopRepository.findFirstByUserOrderByCreatedAtDesc(user);
+		Optional<ImageKeyword> imageKeyword = imageKeywordRepository.findFirstByUserOrderByCreatedAtDesc(user);
+
+		// 두 결과 모두 없는 경우
+		if (workshop.isEmpty() && imageKeyword.isEmpty()) {
+			return FragranceConverter.toMyPerfumeResult(false, List.of());
+		}
+
+		String selectedJson = null;
+
+		// 더 최신 결과 선택
+		if (workshop.isPresent() && imageKeyword.isPresent()) {
+			// 두 결과 모두 있는 경우 createdAt 비교하여 최신 선택
+			if (workshop.get().getCreatedAt().isAfter(imageKeyword.get().getCreatedAt())) {
+				selectedJson = workshop.get().getRecommendedFragranceJson();
+			} else {
+				selectedJson = imageKeyword.get().getRecommendedFragranceJson();
+			}
+		} else if (workshop.isPresent()) {
+			// 향수공방 결과만 있는 경우
+			selectedJson = workshop.get().getRecommendedFragranceJson();
+		} else {
+			// 이미지키워드 결과만 있는 경우
+			selectedJson = imageKeyword.get().getRecommendedFragranceJson();
+		}
+
+		// JSON 파싱하여 MyPerfume 리스트로 변환
+		List<FragranceResponseDTO.MyPerfume> myPerfumeList = parseRecommendedFragranceJson(selectedJson);
+
+		return FragranceConverter.toMyPerfumeResult(true, myPerfumeList);
+	}
+
+	/**recommendedFragranceJson 필드를 파싱하여 MyPerfume 리스트로 변환*/
+	private List<FragranceResponseDTO.MyPerfume> parseRecommendedFragranceJson(String jsonString) {
+		try {
+			if (jsonString == null || jsonString.trim().isEmpty()) {
+				return List.of();
+			}
+
+			// JSON 배열을 파싱하여 MyPerfume DTO로 변환
+			TypeReference<List<FragranceResponseDTO.MyPerfume>> typeRef =
+				new TypeReference<List<FragranceResponseDTO.MyPerfume>>() {
+				};
+
+			List<FragranceResponseDTO.MyPerfume> perfumeList = objectMapper.readValue(jsonString, typeRef);
+
+			// null 체크 및 필수 필드 검증
+			return perfumeList.stream()
+				.filter(perfume -> perfume != null &&
+					perfume.getBrand() != null &&
+					perfume.getName() != null)
+				.collect(Collectors.toList());
+
+		} catch (Exception e) {
+			// JSON 파싱 실패 시 빈 리스트 반환
+			return List.of();
+		}
 	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
+++ b/src/main/java/PerfumeOnMe/spring/web/controller/FragranceController.java
@@ -201,4 +201,18 @@ public class FragranceController {
 		FragranceResponseDTO.FragranceMdChoiceResult result = fragranceService.getFragranceMdChoice(userDetails);
 		return ResponseEntity.ok(ApiResponse.onSuccess(result));
 	}
+
+	@GetMapping("/my-perfume")
+	@Operation(
+		summary = "메인페이지 나만의 향수 조회 API",
+		description = "이미지키워드나 향수공방 중 가장 최근 결과에서 추천향수를 반환하는 API입니다.",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "성공입니다", content = @Content(mediaType = "application/json", schema = @Schema(implementation = FragranceResponseDTO.FragranceMyPerfumeResult.class))),
+		}
+	)
+	public ResponseEntity<ApiResponse<FragranceResponseDTO.FragranceMyPerfumeResult>> getFragrancesMyPerfume(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		FragranceResponseDTO.FragranceMyPerfumeResult result = fragranceService.getFragranceMyPerfume(userDetails);
+		return ResponseEntity.ok(ApiResponse.onSuccess(result));
+	}
 }

--- a/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
+++ b/src/main/java/PerfumeOnMe/spring/web/dto/fragrance/FragranceResponseDTO.java
@@ -123,6 +123,26 @@ public class FragranceResponseDTO {
 		private String nickname;
 	}
 
+	// 메인페이지 나만의 향수 DTO
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class FragranceMyPerfumeResult {
+		private boolean exists;
+		private List<MyPerfume> myPerfumeList;
+	}
+
+	// 나만의 향수
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class MyPerfume {
+		private String brand;
+		private String name;
+		private String imageUrl;
+	}
 }
 
 


### PR DESCRIPTION
## 💡 관련 이슈

- #123 

## 📢 작업 내용

  - 메인페이지 나만의 향수 조회 API 구현 (GET /fragrances/my-perfume)
  - 이미지키워드와 향수공방 결과 중 최신 데이터를 선택하는 로직 구현
  - recommendedFragranceJson 필드 JSON 파싱 기능 추가
  - FragranceConverter.toMyPerfumeResult() 메서드 추가
  - FragranceServiceImpl.getFragranceMyPerfume() 메서드 완성
  - FragranceServiceImpl.parseRecommendedFragranceJson() private 메서드 추가
  - Controller에 Swagger API 문서화 어노테이션 추가

 주요 구현 내용:

  1. API 엔드포인트: GET /fragrances/my-perfume
  2. 응답 형태:
```
  {
    "exists": true,
    "myPerfumeList": [
      {
        "brand": "브랜드명",
        "name": "향수명",
        "imageUrl": "이미지 URL"  }   
     ] 
 }
```
  3. 비즈니스 로직: 사용자의 최신 이미지키워드 또는 향수공방 결과에서 추천향수 추출
  4. 예외 처리: 데이터가 없는 경우 exists: false, JSON 파싱 실패 시 빈 리스트 반환
  
## 🗨️ 리뷰 요구사항(선택)

  - JSON 파싱 로직의 예외 처리가 적절한지 확인 부탁드립니다
  - 최신 데이터 선택 로직(createdAt 비교)이 올바른지 검토 부탁드립니다

<img width="1072" height="604" alt="image" src="https://github.com/user-attachments/assets/551cfd3e-3da9-4de8-834d-9450127845d3" />

## ✅ 체크리스트

- [x]  코드가 정상적으로 컴파일되나요?
- [x]  이슈 내용을 전부 구현했나요?
- [x]  작업 기간 내에 개발을 완료했나요?
- [x]  리뷰어를 선택했나요?
- [x]  라벨을 지정했나요?
